### PR TITLE
feat(cve): NVD CVE intelligence + vendor-aware matching + detailed CVE  page

### DIFF
--- a/app/api/settings/api-keys/route.ts
+++ b/app/api/settings/api-keys/route.ts
@@ -19,7 +19,12 @@ function mask(s: string) {
 }
 
 export async function GET() {
-  const keys = await prisma.apiKey.findMany({ orderBy: { createdAt: "asc" } });
+  // NVD (CVE_MATCH) credentials are managed in the dedicated CVE settings card,
+  // so this VirusTotal-oriented list excludes them.
+  const keys = await prisma.apiKey.findMany({
+    where: { provider: EngineProvider.VIRUSTOTAL },
+    orderBy: { createdAt: "asc" },
+  });
   return NextResponse.json({
     keys: keys.map((k) => {
       const usage = resolveUsageCounters(k);

--- a/app/api/settings/cve/fetch/route.ts
+++ b/app/api/settings/cve/fetch/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { CveFetchStatus } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { getNvdApiKey } from "@/lib/nvd-key";
+import { getCveFetchQueue } from "@/lib/queue";
+import { resolveStartDate, type CveFetchRange } from "@/lib/cve-fetch";
+
+const bodySchema = z.object({
+  range: z.enum(["7d", "30d", "6mo", "1y", "custom"]),
+  customStart: z.string().datetime().optional(),
+});
+
+export async function POST(req: Request) {
+  const json = await req.json().catch(() => null);
+  const parsed = bodySchema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+
+  // Guard: don't start a second fetch while one is running.
+  const state = await prisma.cveFetchState.findUnique({ where: { id: "singleton" } });
+  if (state?.status === CveFetchStatus.RUNNING) {
+    return NextResponse.json({ error: "A CVE fetch is already running." }, { status: 409 });
+  }
+
+  const apiKey = await getNvdApiKey(prisma);
+  const proxyRow = await prisma.appSetting.findUnique({ where: { key: "global_proxy_url" } });
+  const proxyUrl = (proxyRow?.value as { url?: string | null } | undefined)?.url ?? null;
+
+  const range = parsed.data.range as CveFetchRange;
+  const customStart = parsed.data.customStart ? new Date(parsed.data.customStart) : null;
+  const startDate = resolveStartDate(range, customStart);
+
+  // Mark RUNNING immediately so the UI reflects state before the worker picks up.
+  await prisma.cveFetchState.upsert({
+    where: { id: "singleton" },
+    create: { id: "singleton", status: CveFetchStatus.RUNNING, progressCurrent: 0, progressTotal: 0 },
+    update: { status: CveFetchStatus.RUNNING, errorMessage: null, progressCurrent: 0, progressTotal: 0 },
+  });
+
+  const queue = getCveFetchQueue();
+  await queue.add("cve-fetch", {
+    apiKey,
+    startDate: startDate.toISOString(),
+    proxyUrl,
+  });
+
+  return NextResponse.json({ ok: true, startDate: startDate.toISOString() });
+}

--- a/app/api/settings/cve/route.ts
+++ b/app/api/settings/cve/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+import { setNvdApiKey, hasNvdApiKey } from "@/lib/nvd-key";
+import { getCveFetchState } from "@/lib/cve-fetch";
+
+const bodySchema = z.object({
+  apiKey: z.preprocess((v) => (v === "" ? null : v), z.union([z.string().min(20).max(200), z.null()])),
+});
+
+export async function GET() {
+  const [state, keyPresent, oldest] = await Promise.all([
+    getCveFetchState(prisma),
+    hasNvdApiKey(prisma),
+    prisma.cve.findFirst({ orderBy: { published: "asc" }, select: { published: true } }),
+  ]);
+  return NextResponse.json({
+    hasApiKey: keyPresent,
+    status: state.status,
+    coveredUntil: state.coveredUntil?.toISOString() ?? null,
+    oldestPublished: oldest?.published.toISOString() ?? null,
+    lastFetchedAt: state.lastFetchedAt?.toISOString() ?? null,
+    totalStored: state.totalStored,
+    progressCurrent: state.progressCurrent,
+    progressTotal: state.progressTotal,
+    errorMessage: state.errorMessage,
+  });
+}
+
+export async function POST(req: Request) {
+  const json = await req.json().catch(() => null);
+  const parsed = bodySchema.safeParse(json);
+  if (!parsed.success) return NextResponse.json({ error: "Invalid API key" }, { status: 400 });
+  await setNvdApiKey(prisma, parsed.data.apiKey);
+  return NextResponse.json({ ok: true, hasApiKey: Boolean(parsed.data.apiKey) });
+}

--- a/app/api/targets/[id]/subdomains/[hostnameNormalized]/technologies/route.ts
+++ b/app/api/targets/[id]/subdomains/[hostnameNormalized]/technologies/route.ts
@@ -30,6 +30,15 @@ export async function GET(
         website: true,
         cpe: true,
         lastSeenAt: true,
+        cveMatches: {
+          select: {
+            cveId: true,
+            matchedVersion: true,
+            cve: { select: { cvssSeverity: true, cvssScore: true } },
+          },
+          orderBy: { cve: { cvssScore: "desc" } },
+          take: 100,
+        },
       },
     });
 
@@ -46,6 +55,11 @@ export async function GET(
         website: t.website,
         cpe: t.cpe,
         lastSeenAt: t.lastSeenAt.toISOString(),
+        cves: t.cveMatches.map((m) => ({
+          cveId: m.cveId,
+          severity: m.cve.cvssSeverity,
+          score: m.cve.cvssScore,
+        })),
       })),
     });
   } catch (error) {

--- a/app/intel/cve/[id]/page.tsx
+++ b/app/intel/cve/[id]/page.tsx
@@ -1,0 +1,245 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { PageHeader } from "@/components/page-header";
+import { TopBar } from "@/components/top-bar";
+import { IconArrowUpRight } from "@/components/ui-icons";
+import { prisma } from "@/lib/prisma";
+import { formatScanDateTime } from "@/lib/scan-format";
+import {
+  severityBadgeClass,
+  parseAffectedConfigs,
+  normalizeProductToken,
+} from "@/lib/cve-format";
+import { CveDescription } from "@/components/intel/cve-description";
+
+export const dynamic = "force-dynamic";
+
+export default async function CveDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const cveId = decodeURIComponent(id);
+
+  const cve = await prisma.cve.findUnique({ where: { id: cveId } });
+  if (!cve) notFound();
+
+  // Affected hosts: subdomain technologies matched to this CVE.
+  const matches = await prisma.subdomainTechnologyCve.findMany({
+    where: { cveId },
+    select: {
+      matchedVersion: true,
+      subdomainTechnology: {
+        select: {
+          name: true,
+          version: true,
+          cpe: true,
+          subdomain: {
+            select: { hostnameNormalized: true, targetDomainId: true },
+          },
+        },
+      },
+    },
+    take: 500,
+  });
+
+  // Parse the NVD CPE configuration into readable "affected product" rows.
+  const affectedConfigs = parseAffectedConfigs(cve.cpeConfigs);
+
+  // Resolve each affected host to the config entry it matched, so we can show
+  // the exact version range (straight from NVD) that triggered the match.
+  const hostRows = matches.map((m) => {
+    const tech = m.subdomainTechnology;
+    const techToken = normalizeProductToken(tech.name);
+    const cpeProduct = tech.cpe ? tech.cpe.split(":")[4] ?? "" : "";
+    const matchedConfig =
+      affectedConfigs.find(
+        (c) => normalizeProductToken(c.product) === normalizeProductToken(cpeProduct),
+      ) ??
+      affectedConfigs.find(
+        (c) =>
+          normalizeProductToken(c.product) === techToken ||
+          techToken.includes(normalizeProductToken(c.product)) ||
+          normalizeProductToken(c.product).includes(techToken),
+      ) ??
+      null;
+    return {
+      host: tech.subdomain?.hostnameNormalized ?? "—",
+      techName: tech.name,
+      version: m.matchedVersion ?? tech.version ?? "—",
+      product: matchedConfig?.label ?? cpeProduct ?? "—",
+      versionRule: matchedConfig?.versionLabel ?? "—",
+    };
+  });
+
+  return (
+    <>
+      <TopBar breadcrumb={`/ intel / cve / ${cveId}`} />
+      <main className="min-h-0 flex-1 overflow-y-auto px-6 py-8">
+        <Link
+          href="/intel/cve"
+          className="text-[12px] text-muted transition-colors hover:text-cream"
+        >
+          ← Back to CVE database
+        </Link>
+
+        <div className="mt-3 flex flex-wrap items-center gap-3">
+          <PageHeader eyebrow="Intel · CVE" title={cve.id} />
+          {cve.cvssSeverity ? (
+            <span
+              className={`mt-6 inline-block rounded-md px-2.5 py-1 text-[11px] font-semibold ${severityBadgeClass(
+                cve.cvssSeverity,
+              )}`}
+            >
+              {cve.cvssSeverity}
+              {cve.cvssScore != null ? ` · ${cve.cvssScore.toFixed(1)}` : ""}
+            </span>
+          ) : null}
+        </div>
+
+        {/* Metadata */}
+        <div className="mt-6 grid grid-cols-2 gap-3 sm:grid-cols-4">
+          {[
+            ["Published", formatScanDateTime(cve.published)],
+            ["Last modified", formatScanDateTime(cve.lastModified)],
+            ["CVSS score", cve.cvssScore != null ? cve.cvssScore.toFixed(1) : "—"],
+            ["Affected hosts", matches.length.toLocaleString()],
+          ].map(([label, val]) => (
+            <div key={label} className="rounded-xl border border-line bg-black/10 px-3 py-2.5">
+              <div className="text-[10px] font-semibold uppercase tracking-wider text-muted">
+                {label}
+              </div>
+              <div className="mt-1 font-mono text-[11px] text-cream">{val}</div>
+            </div>
+          ))}
+        </div>
+
+        {/* Description */}
+        <div className="mt-6 glass-panel rounded-2xl p-6">
+          <div className="text-[10px] font-semibold uppercase tracking-[0.25em] text-accent">
+            Description
+          </div>
+          <CveDescription
+            text={cve.description}
+            className="mt-3 text-[13px] leading-relaxed text-cream/90"
+          />
+
+          {cve.cvssVector ? (
+            <div className="mt-4">
+              <div className="text-[10px] font-semibold uppercase tracking-wider text-muted">
+                CVSS vector
+              </div>
+              <div className="mt-1 font-mono text-[11px] text-cream">{cve.cvssVector}</div>
+            </div>
+          ) : null}
+
+        </div>
+
+        {/* Affected products / configurations (parsed from NVD cpeConfigs) */}
+        {affectedConfigs.length > 0 ? (
+          <div className="mt-6 glass-panel overflow-hidden rounded-2xl">
+            <div className="border-b border-line bg-[var(--table-header-bg)] px-5 py-4">
+              <div className="text-[13px] font-semibold text-cream">
+                Affected configurations
+              </div>
+              <div className="mt-1 text-[12px] text-muted">
+                Vulnerable products and version ranges as declared in the NVD CPE
+                configuration for this CVE.
+              </div>
+            </div>
+            <div className="hidden border-b border-line bg-[var(--table-header-bg)] px-5 py-2.5 text-[10px] font-semibold uppercase tracking-wider text-muted sm:grid sm:grid-cols-12 sm:gap-3">
+              <div className="col-span-7">Product</div>
+              <div className="col-span-5">Affected versions</div>
+            </div>
+            <div className="divide-y divide-line">
+              {affectedConfigs.map((c) => (
+                <div
+                  key={c.label + c.versionLabel}
+                  className="flex flex-col gap-1 px-5 py-3 sm:grid sm:grid-cols-12 sm:items-center sm:gap-3"
+                >
+                  <div className="col-span-7 min-w-0 truncate font-mono text-[12px] text-cream">
+                    {c.label}
+                  </div>
+                  <div className="col-span-5 font-mono text-[11px] text-muted tabular-nums">
+                    {c.versionLabel}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : null}
+
+        {/* References */}
+        {cve.references.length > 0 ? (
+          <div className="mt-6 glass-panel rounded-2xl p-6">
+            <div className="text-[10px] font-semibold uppercase tracking-[0.25em] text-accent">
+              References
+            </div>
+            <div className="mt-3 flex flex-col gap-2">
+              {cve.references.map((url) => (
+                <a
+                  key={url}
+                  href={url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-1.5 truncate font-mono text-[11px] text-accent hover:text-accent-dim"
+                >
+                  <IconArrowUpRight className="size-3 shrink-0" />
+                  <span className="truncate">{url}</span>
+                </a>
+              ))}
+            </div>
+          </div>
+        ) : null}
+
+        {/* Affected hosts */}
+        <div className="mt-6 glass-panel overflow-hidden rounded-2xl">
+          <div className="border-b border-line bg-[var(--table-header-bg)] px-5 py-4">
+            <div className="text-[13px] font-semibold text-cream">Affected hosts</div>
+            <div className="mt-1 text-[12px] text-muted">
+              Subdomains where a fingerprinted technology&apos;s version falls inside
+              an affected range above.
+            </div>
+          </div>
+
+          <div className="hidden border-b border-line bg-[var(--table-header-bg)] px-5 py-2.5 text-[10px] font-semibold uppercase tracking-wider text-muted sm:grid sm:grid-cols-12 sm:gap-3">
+            <div className="col-span-4">Host</div>
+            <div className="col-span-3">Technology</div>
+            <div className="col-span-2">Version</div>
+            <div className="col-span-3">Why matched</div>
+          </div>
+
+          <div className="divide-y divide-line">
+            {hostRows.length === 0 ? (
+              <div className="px-5 py-8 text-center text-[13px] text-muted">
+                No hosts currently match this CVE.
+              </div>
+            ) : (
+              hostRows.map((r, i) => (
+                <div
+                  key={`${r.host}-${r.techName}-${i}`}
+                  className="flex flex-col gap-1.5 px-5 py-3 sm:grid sm:grid-cols-12 sm:items-center sm:gap-3"
+                >
+                  <div className="col-span-4 min-w-0 truncate font-mono text-[12px] text-cream">
+                    {r.host}
+                  </div>
+                  <div className="col-span-3 min-w-0 truncate font-mono text-[11px] text-muted">
+                    {r.techName}
+                  </div>
+                  <div className="col-span-2 font-mono text-[11px] text-cream tabular-nums">
+                    {r.version}
+                  </div>
+                  <div className="col-span-3 min-w-0 truncate font-mono text-[10px] text-muted">
+                    <span className="text-cream/70">{r.product}</span>{" "}
+                    <span className="text-muted">{r.versionRule}</span>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/app/intel/cve/page.tsx
+++ b/app/intel/cve/page.tsx
@@ -1,0 +1,212 @@
+import Link from "next/link";
+import { Prisma } from "@prisma/client";
+import { PageHeader } from "@/components/page-header";
+import { TopBar } from "@/components/top-bar";
+import { TablePagination, normalizePageSize } from "@/components/table-pagination";
+import { CveListFilters } from "@/components/intel/cve-list-filters";
+import { IconChevronRight } from "@/components/ui-icons";
+import { prisma } from "@/lib/prisma";
+import { formatScanDateTime } from "@/lib/scan-format";
+import { severityBadgeClass } from "@/lib/cve-format";
+
+export const dynamic = "force-dynamic";
+
+function sp(v: string | string[] | undefined): string {
+  if (typeof v === "string") return v;
+  if (Array.isArray(v)) return v[0] ?? "";
+  return "";
+}
+function asPosInt(v: string | undefined, fallback: number) {
+  const n = Number(v);
+  return Number.isFinite(n) && n >= 1 ? Math.floor(n) : fallback;
+}
+
+const SEVERITIES = ["CRITICAL", "HIGH", "MEDIUM", "LOW"] as const;
+
+/** Fixed columns + one flexible description (minmax(0,1fr) lets cells shrink). */
+const CVE_GRID = "150px 96px 56px minmax(0,1fr) 150px 96px";
+
+export default async function CveDbPage({
+  searchParams,
+}: {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const rawSp = (await searchParams) ?? {};
+  const q = sp(rawSp.q).trim();
+  const severity = sp(rawSp.severity).toUpperCase();
+  const validSeverity = (SEVERITIES as readonly string[]).includes(severity) ? severity : "";
+  const page = asPosInt(sp(rawSp.page), 1);
+  const perPage = normalizePageSize(sp(rawSp.perPage) || null);
+
+  const where: Prisma.CveWhereInput = {
+    ...(validSeverity ? { cvssSeverity: validSeverity } : {}),
+    ...(q
+      ? {
+          OR: [
+            { id: { contains: q, mode: "insensitive" } },
+            { description: { contains: q, mode: "insensitive" } },
+          ],
+        }
+      : {}),
+  };
+
+  const [total, totalStored] = await Promise.all([
+    prisma.cve.count({ where }),
+    prisma.cve.count(),
+  ]);
+  const totalPages = Math.max(1, Math.ceil(total / perPage));
+  const safePage = Math.min(page, totalPages);
+
+  const cves = await prisma.cve.findMany({
+    where,
+    orderBy: { published: "desc" },
+    skip: (safePage - 1) * perPage,
+    take: perPage,
+    select: {
+      id: true,
+      published: true,
+      cvssScore: true,
+      cvssSeverity: true,
+      description: true,
+      cpeProducts: true,
+    },
+  });
+
+  const fixedParams: Record<string, string> = {};
+  if (q) fixedParams.q = q;
+  if (validSeverity) fixedParams.severity = validSeverity;
+
+  return (
+    <>
+      <TopBar breadcrumb="/ intel / cve" />
+      <main className="min-h-0 flex-1 overflow-y-auto px-6 py-8">
+        <PageHeader
+          eyebrow="Intel"
+          title="CVE database"
+          description={`${totalStored.toLocaleString()} CVEs stored locally from the NVD. Sorted by publish date.`}
+        />
+
+        <div className="mt-6">
+          <CveListFilters
+            initialQuery={q}
+            severity={validSeverity}
+            severities={SEVERITIES as unknown as string[]}
+          />
+        </div>
+
+        <div className="mt-4 glass-panel overflow-hidden rounded-2xl">
+          {/*
+            Stable layout: an explicit grid template with fixed-width columns and a
+            single flexible (minmax(0,1fr)) description column. minmax(0,*) is what
+            actually allows the truncating cells to shrink instead of overflowing.
+          */}
+          <div
+            className="hidden items-center gap-3 border-b border-line bg-[var(--table-header-bg)] px-5 py-2.5 text-[10px] font-semibold uppercase tracking-wider text-muted lg:grid"
+            style={{ gridTemplateColumns: CVE_GRID }}
+          >
+            <div>CVE ID</div>
+            <div>Severity</div>
+            <div className="text-right">Score</div>
+            <div>Description</div>
+            <div>Published</div>
+            <div className="text-right">Products</div>
+          </div>
+
+          <div className="divide-y divide-line">
+            {cves.length === 0 ? (
+              <div className="px-5 py-10 text-center">
+                <div className="text-[13px] text-muted">
+                  {totalStored === 0
+                    ? "No CVEs stored yet. Fetch CVE data from General Settings."
+                    : "No CVEs match these filters."}
+                </div>
+              </div>
+            ) : (
+              cves.map((c) => (
+                <Link
+                  key={c.id}
+                  href={`/intel/cve/${encodeURIComponent(c.id)}`}
+                  className="group block px-5 py-3 text-left transition-colors hover:bg-white/5 focus:outline-none focus-visible:bg-white/5"
+                >
+                  {/* Desktop: aligned grid. Mobile: stacked card. */}
+                  <div
+                    className="hidden items-center gap-3 lg:grid"
+                    style={{ gridTemplateColumns: CVE_GRID }}
+                  >
+                    <div className="min-w-0 truncate font-mono text-[12px] text-cream group-hover:text-accent">
+                      {c.id}
+                    </div>
+                    <div className="min-w-0">
+                      {c.cvssSeverity ? (
+                        <span
+                          className={`inline-block rounded-md px-2 py-0.5 text-[10px] font-semibold ${severityBadgeClass(
+                            c.cvssSeverity,
+                          )}`}
+                        >
+                          {c.cvssSeverity}
+                        </span>
+                      ) : (
+                        <span className="text-[11px] text-muted">—</span>
+                      )}
+                    </div>
+                    <div className="text-right font-mono text-[11px] text-cream tabular-nums">
+                      {c.cvssScore != null ? c.cvssScore.toFixed(1) : "—"}
+                    </div>
+                    <div className="min-w-0 truncate text-[11px] text-muted" title={c.description}>
+                      {c.description}
+                    </div>
+                    <div className="whitespace-nowrap font-mono text-[11px] text-muted tabular-nums">
+                      {formatScanDateTime(c.published)}
+                    </div>
+                    <div className="flex items-center justify-end gap-2">
+                      <span className="font-mono text-[11px] text-cream">
+                        {c.cpeProducts.length.toLocaleString()}
+                      </span>
+                      <IconChevronRight
+                        className="size-4 shrink-0 text-muted opacity-60 transition-all group-hover:text-accent group-hover:opacity-100"
+                        aria-hidden
+                      />
+                    </div>
+                  </div>
+
+                  {/* Mobile stacked layout */}
+                  <div className="flex flex-col gap-1.5 lg:hidden">
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="min-w-0 truncate font-mono text-[12px] text-cream group-hover:text-accent">
+                        {c.id}
+                      </span>
+                      {c.cvssSeverity ? (
+                        <span
+                          className={`shrink-0 rounded-md px-2 py-0.5 text-[10px] font-semibold ${severityBadgeClass(
+                            c.cvssSeverity,
+                          )}`}
+                        >
+                          {c.cvssSeverity}
+                          {c.cvssScore != null ? ` · ${c.cvssScore.toFixed(1)}` : ""}
+                        </span>
+                      ) : null}
+                    </div>
+                    <div className="line-clamp-2 text-[11px] text-muted">{c.description}</div>
+                    <div className="flex items-center justify-between text-[10px] text-muted">
+                      <span className="font-mono tabular-nums">{formatScanDateTime(c.published)}</span>
+                      <span className="font-mono">{c.cpeProducts.length.toLocaleString()} products</span>
+                    </div>
+                  </div>
+                </Link>
+              ))
+            )}
+          </div>
+
+          <TablePagination
+            currentPage={safePage}
+            totalPages={totalPages}
+            totalItems={total}
+            perPage={perPage}
+            basePath="/intel/cve"
+            fixedParams={fixedParams}
+          />
+        </div>
+      </main>
+    </>
+  );
+}

--- a/app/scans/[id]/observed/page.tsx
+++ b/app/scans/[id]/observed/page.tsx
@@ -10,6 +10,7 @@ import {
   IconGlobe,
   IconLink,
   IconServer,
+  IconShield,
   IconTerminal,
 } from "@/components/ui-icons";
 import { ScanComparePanel } from "@/components/scan-compare-panel";
@@ -20,6 +21,7 @@ import { ScanMetricCards } from "@/components/scans/scan-metric-cards";
 import { ScanSummaryTab } from "@/components/scans/scan-summary-tab";
 import { ScanIpsTab } from "@/components/scans/scan-ips-tab";
 import { ScanTechTab, type ScanTechRow } from "@/components/scans/scan-tech-tab";
+import { ScanCveTab, type ScanCveRow } from "@/components/scans/scan-cve-tab";
 import { SubdomainSearchBar } from "@/components/subdomain-search-bar";
 import { ObservedSubdomainRow } from "@/components/scans/observed-subdomain-row";
 import { UrlFiltersToolbar } from "@/components/url-filters-toolbar";
@@ -142,6 +144,7 @@ export default async function ScanObservedPage({
     tabRaw === "urls" ||
     tabRaw === "ips" ||
     tabRaw === "tech" ||
+    tabRaw === "cves" ||
     tabRaw === "findings" ||
     tabRaw === "compare"
       ? tabRaw
@@ -236,6 +239,14 @@ export default async function ScanObservedPage({
     select: { name: true },
   });
   const observedTechCount = techDistinct.length;
+
+  // Always compute the matched-CVE count so the tab badge shows before activation.
+  const cveDistinct = await prisma.subdomainTechnologyCve.findMany({
+    where: { subdomainTechnology: { scanJobId: id } },
+    distinct: ["cveId"],
+    select: { cveId: true },
+  });
+  const observedCveCount = cveDistinct.length;
 
   const urlCategoryCounts =
     availability.urls === "ready"
@@ -728,6 +739,99 @@ export default async function ScanObservedPage({
     safeTechPage * perPage,
   );
 
+  /* ── Matched CVEs ── */
+  // Group SubdomainTechnologyCve rows (matched in this scan) by CVE.
+  const cveRecords =
+    tab === "cves"
+      ? await prisma.subdomainTechnologyCve.findMany({
+          where: { subdomainTechnology: { scanJobId: id } },
+          select: {
+            cveId: true,
+            matchedVersion: true,
+            cve: {
+              select: {
+                published: true,
+                description: true,
+                cvssSeverity: true,
+                cvssScore: true,
+              },
+            },
+            subdomainTechnology: {
+              select: {
+                name: true,
+                subdomain: { select: { hostnameNormalized: true } },
+              },
+            },
+          },
+        })
+      : [];
+
+  const cveGrouped: ScanCveRow[] = (() => {
+    if (tab !== "cves") return [];
+    const map = new Map<
+      string,
+      {
+        cveId: string;
+        severity: string | null;
+        score: number | null;
+        published: string;
+        description: string;
+        hosts: Map<string, { technology: string; matchedVersion: string | null }>;
+      }
+    >();
+    for (const r of cveRecords) {
+      const host = r.subdomainTechnology.subdomain?.hostnameNormalized;
+      if (!host) continue;
+      let g = map.get(r.cveId);
+      if (!g) {
+        g = {
+          cveId: r.cveId,
+          severity: r.cve.cvssSeverity,
+          score: r.cve.cvssScore,
+          published: r.cve.published.toISOString(),
+          description: r.cve.description,
+          hosts: new Map(),
+        };
+        map.set(r.cveId, g);
+      }
+      // Key by host+technology so a host can appear once per matching tech.
+      const key = `${host}::${r.subdomainTechnology.name}`;
+      if (!g.hosts.has(key)) {
+        g.hosts.set(key, {
+          technology: r.subdomainTechnology.name,
+          matchedVersion: r.matchedVersion,
+        });
+      }
+    }
+    return Array.from(map.values())
+      .map((g) => ({
+        cveId: g.cveId,
+        severity: g.severity,
+        score: g.score,
+        published: g.published,
+        description: g.description,
+        hosts: Array.from(g.hosts.entries())
+          .map(([key, v]) => ({
+            hostnameNormalized: key.split("::")[0],
+            technology: v.technology,
+            matchedVersion: v.matchedVersion,
+          }))
+          .sort((a, b) => a.hostnameNormalized.localeCompare(b.hostnameNormalized)),
+        hostCount: g.hosts.size,
+      }))
+      .sort(
+        (a, b) =>
+          (b.score ?? 0) - (a.score ?? 0) ||
+          b.hostCount - a.hostCount ||
+          a.cveId.localeCompare(b.cveId),
+      );
+  })();
+
+  const cveTotal = cveGrouped.length;
+  const cvePages = Math.max(1, Math.ceil(cveTotal / perPage));
+  const safeCvePage = Math.min(page, cvePages);
+  const cveRows = cveGrouped.slice((safeCvePage - 1) * perPage, safeCvePage * perPage);
+
   function tabHref(nextTab: string) {
     const q = new URLSearchParams();
     q.set("tab", nextTab);
@@ -774,6 +878,13 @@ export default async function ScanObservedPage({
       icon: IconTerminal,
       href: tabHref("tech"),
       count: countLabel(observedTechCount),
+    },
+    {
+      key: "cves",
+      label: "CVEs",
+      icon: IconShield,
+      href: tabHref("cves"),
+      count: countLabel(observedCveCount),
     },
     {
       key: "findings",
@@ -1380,6 +1491,18 @@ export default async function ScanObservedPage({
               totalItems={techTotal}
               currentPage={safeTechPage}
               totalPages={techPages}
+              perPage={perPage}
+              basePath={basePath}
+              isCompleted={isCompleted}
+            />
+          )}
+
+          {tab === "cves" && (
+            <ScanCveTab
+              cves={cveRows}
+              totalItems={cveTotal}
+              currentPage={safeCvePage}
+              totalPages={cvePages}
               perPage={perPage}
               basePath={basePath}
               isCompleted={isCompleted}

--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -4,6 +4,7 @@ import { AppShellChrome } from "@/components/app-shell-chrome";
 import { IpSightingPanelProvider } from "@/components/ip-sighting-panel-provider";
 import { HostnameSightingPanelProvider } from "@/components/hostname-sighting-panel-provider";
 import { TechHostsPanelProvider } from "@/components/scans/tech-hosts-panel-provider";
+import { CveHostsPanelProvider } from "@/components/scans/cve-hosts-panel-provider";
 import { loadSidebarExtensionCategories } from "@/lib/extension-category";
 import { prisma } from "@/lib/prisma";
 
@@ -14,6 +15,7 @@ export async function AppShell({ children }: { children: React.ReactNode }) {
     <IpSightingPanelProvider>
       <HostnameSightingPanelProvider>
         <TechHostsPanelProvider>
+        <CveHostsPanelProvider>
         <div className="relative min-h-screen">
           <AppShellChrome />
 
@@ -26,6 +28,7 @@ export async function AppShell({ children }: { children: React.ReactNode }) {
             </div>
           </div>
         </div>
+        </CveHostsPanelProvider>
         </TechHostsPanelProvider>
       </HostnameSightingPanelProvider>
     </IpSightingPanelProvider>

--- a/components/hostname-sighting-panel.tsx
+++ b/components/hostname-sighting-panel.tsx
@@ -5,6 +5,7 @@ import { createPortal } from "react-dom";
 import Link from "next/link";
 import { apiUrl } from "@/lib/api-url";
 import { TechIcon } from "@/components/scans/tech-icon";
+import { severityBadgeClass } from "@/lib/cve-format";
 import { IconArrowUpRight, IconChevronDown, IconCopy, IconInfo, IconX } from "@/components/ui-icons";
 import {
   formatPassiveDnsPanelDateTime,
@@ -48,6 +49,7 @@ type TechnologyItem = {
   website: string | null;
   cpe: string | null;
   lastSeenAt: string;
+  cves?: Array<{ cveId: string; severity: string | null; score: number | null }>;
 };
 
 type TechnologiesData = {
@@ -339,7 +341,11 @@ function SubdomainTechnologiesSection({
               >
                 <TechIcon name={t.name} iconName={t.iconName} size={14} />
                 <span className="truncate">{label}</span>
-                {cats ? (
+                {t.cves && t.cves.length > 0 ? (
+                  <span className="shrink-0 rounded bg-warn/20 px-1 text-[9px] font-bold text-warn">
+                    {t.cves.length} CVE
+                  </span>
+                ) : cats ? (
                   <span className="max-w-[120px] truncate text-[9px] font-medium uppercase tracking-wide text-muted">
                     {t.categories[0]}
                   </span>
@@ -375,6 +381,65 @@ function SubdomainTechnologiesSection({
           ) : null}
         </div>
       )}
+
+      <SubdomainCvesList techs={techs} />
+    </div>
+  );
+}
+
+function SubdomainCvesList({ techs }: { techs: TechnologyItem[] }) {
+  // Aggregate unique CVEs across this host's technologies.
+  const map = new Map<string, { cveId: string; severity: string | null; score: number | null }>();
+  for (const t of techs) {
+    for (const c of t.cves ?? []) {
+      if (!map.has(c.cveId)) map.set(c.cveId, c);
+    }
+  }
+  const cves = Array.from(map.values()).sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
+  if (cves.length === 0) return null;
+
+  return (
+    <div className="mt-6 text-left">
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <div className="min-w-0">
+          <h3 className="text-[13px] font-semibold text-cream">Matched CVEs</h3>
+          <p className="mt-1 text-[11px] leading-relaxed text-muted">
+            Vulnerabilities matching this host&rsquo;s detected technologies.
+          </p>
+        </div>
+        <span className="shrink-0 rounded-md bg-warn/20 px-2 py-0.5 font-mono text-[10px] font-bold text-warn">
+          {cves.length}
+        </span>
+      </div>
+
+      <div className="overflow-hidden rounded-lg border border-line text-left">
+        <div className="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-x-2 border-b border-line bg-[var(--table-header-bg)] px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted">
+          <div>CVE</div>
+          <div>Severity</div>
+          <div>Score</div>
+        </div>
+        <div className="divide-y divide-line">
+          {cves.slice(0, 50).map((c) => (
+            <Link
+              key={c.cveId}
+              href={`/intel/cve/${encodeURIComponent(c.cveId)}`}
+              className="group grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-x-2 px-2 py-1 transition-colors hover:bg-white/5"
+            >
+              <div className="min-w-0 truncate font-mono text-[10px] text-cream group-hover:text-accent">
+                {c.cveId}
+              </div>
+              <div
+                className={`justify-self-start rounded px-1.5 py-0.5 text-[9px] font-semibold ${severityBadgeClass(c.severity)}`}
+              >
+                {c.severity ?? "—"}
+              </div>
+              <div className="justify-self-end font-mono text-[10px] text-cream tabular-nums">
+                {c.score != null ? c.score.toFixed(1) : "—"}
+              </div>
+            </Link>
+          ))}
+        </div>
+      </div>
     </div>
   );
 }

--- a/components/intel/cve-description.tsx
+++ b/components/intel/cve-description.tsx
@@ -1,0 +1,48 @@
+import { Fragment } from "react";
+
+/**
+ * Renders an NVD CVE description. NVD descriptions sometimes embed inline code
+ * spans wrapped in matched backticks (e.g. `extract_performers_tags`), which we
+ * surface as small monospace badges. Unmatched/lone backticks (which appear in
+ * older CVEs describing the literal back-tick character) are left as plain text.
+ */
+export function CveDescription({
+  text,
+  className,
+}: {
+  text: string;
+  className?: string;
+}) {
+  return <p className={className}>{renderParts(text)}</p>;
+}
+
+function renderParts(text: string) {
+  // Match content between paired backticks that does not itself contain a backtick.
+  const re = /`([^`\n]+)`/g;
+  const nodes: React.ReactNode[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  let key = 0;
+
+  while ((match = re.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      nodes.push(<Fragment key={`t-${key}`}>{text.slice(lastIndex, match.index)}</Fragment>);
+    }
+    nodes.push(
+      <code
+        key={`c-${key}`}
+        className="mx-0.5 rounded-md border border-line bg-white/[0.06] px-1.5 py-0.5 font-mono text-[0.85em] text-accent"
+      >
+        {match[1]}
+      </code>,
+    );
+    lastIndex = re.lastIndex;
+    key += 1;
+  }
+
+  if (lastIndex < text.length) {
+    nodes.push(<Fragment key={`t-${key}`}>{text.slice(lastIndex)}</Fragment>);
+  }
+
+  return nodes;
+}

--- a/components/intel/cve-list-filters.tsx
+++ b/components/intel/cve-list-filters.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+import { IconSearch, IconX } from "@/components/ui-icons";
+import { severityBadgeClass } from "@/lib/cve-format";
+
+export function CveListFilters({
+  initialQuery,
+  severity,
+  severities,
+}: {
+  initialQuery: string;
+  severity: string;
+  severities: string[];
+}) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [query, setQuery] = useState(initialQuery);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Track the last query we pushed so we don't re-push on external param sync.
+  const lastPushedRef = useRef(initialQuery);
+
+  // Keep input in sync when the URL changes externally (back/forward, clear).
+  useEffect(() => {
+    setQuery(initialQuery);
+    lastPushedRef.current = initialQuery;
+  }, [initialQuery]);
+
+  function buildUrl(next: Record<string, string | null>) {
+    const params = new URLSearchParams(searchParams.toString());
+    for (const [k, v] of Object.entries(next)) {
+      if (v == null || v === "") params.delete(k);
+      else params.set(k, v);
+    }
+    params.delete("page"); // reset pagination on any filter change
+    const qs = params.toString();
+    return qs ? `/intel/cve?${qs}` : "/intel/cve";
+  }
+
+  function pushParams(next: Record<string, string | null>) {
+    router.push(buildUrl(next));
+  }
+
+  // Debounced live search on change.
+  function onQueryChange(value: string) {
+    setQuery(value);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      const trimmed = value.trim();
+      if (trimmed === lastPushedRef.current) return;
+      lastPushedRef.current = trimmed;
+      pushParams({ q: trimmed || null });
+    }, 350);
+  }
+
+  function clearQuery() {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    setQuery("");
+    lastPushedRef.current = "";
+    pushParams({ q: null });
+  }
+
+  // Cleanup on unmount.
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <div className="relative w-full sm:max-w-md">
+        <IconSearch className="pointer-events-none absolute left-3 top-1/2 size-3.5 -translate-y-1/2 text-muted" />
+        <input
+          value={query}
+          onChange={(e) => onQueryChange(e.target.value)}
+          placeholder="Search CVE ID or description…"
+          aria-label="Search CVEs"
+          className="w-full rounded-xl border border-line bg-[var(--tab-bg)] py-2.5 pl-9 pr-9 text-[12px] text-cream outline-none focus:border-accent/50"
+        />
+        {query.length > 0 ? (
+          <button
+            type="button"
+            onClick={clearQuery}
+            title="Clear search"
+            aria-label="Clear search"
+            className="absolute right-1.5 top-1/2 -translate-y-1/2 rounded-md p-1.5 text-muted transition-colors hover:bg-warn/10 hover:text-warn"
+          >
+            <IconX className="size-3.5" />
+          </button>
+        ) : null}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={() => pushParams({ severity: null })}
+          className={[
+            "rounded-lg border px-3 py-1.5 text-[12px] font-medium transition-colors",
+            !severity
+              ? "border-accent/50 bg-accent/15 text-accent"
+              : "border-line bg-[var(--tab-bg)] text-cream hover:bg-[var(--nav-hover-bg)]",
+          ].join(" ")}
+        >
+          All
+        </button>
+        {severities.map((s) => (
+          <button
+            key={s}
+            type="button"
+            onClick={() => pushParams({ severity: severity === s ? null : s })}
+            className={[
+              "rounded-lg border px-3 py-1.5 text-[11px] font-semibold transition-colors",
+              severity === s
+                ? `border-accent/50 ${severityBadgeClass(s)}`
+                : "border-line bg-[var(--tab-bg)] text-muted hover:bg-[var(--nav-hover-bg)]",
+            ].join(" ")}
+          >
+            {s}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/scans/cve-hosts-panel-provider.tsx
+++ b/components/scans/cve-hosts-panel-provider.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { usePathname } from "next/navigation";
+import { CveHostsPanel } from "@/components/scans/cve-hosts-panel";
+import type { ScanCveRow } from "@/components/scans/scan-cve-tab";
+
+type CveHostsPanelContextValue = {
+  cve: ScanCveRow | null;
+  openCvePanel: (cve: ScanCveRow) => void;
+  closeCvePanel: () => void;
+};
+
+const CveHostsPanelContext = createContext<CveHostsPanelContextValue | null>(null);
+
+export function CveHostsPanelProvider({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const [cve, setCve] = useState<ScanCveRow | null>(null);
+
+  const closeCvePanel = useCallback(() => setCve(null), []);
+  const openCvePanel = useCallback((next: ScanCveRow) => {
+    if (!next) return;
+    setCve(next);
+  }, []);
+
+  useEffect(() => {
+    setCve(null);
+  }, [pathname]);
+
+  const value = useMemo(
+    () => ({ cve, openCvePanel, closeCvePanel }),
+    [cve, openCvePanel, closeCvePanel],
+  );
+
+  return (
+    <CveHostsPanelContext.Provider value={value}>
+      {children}
+      {cve ? <CveHostsPanel cve={cve} onClose={closeCvePanel} /> : null}
+    </CveHostsPanelContext.Provider>
+  );
+}
+
+export function useCveHostsPanel() {
+  const ctx = useContext(CveHostsPanelContext);
+  if (!ctx) {
+    throw new Error("useCveHostsPanel must be used within CveHostsPanelProvider");
+  }
+  return ctx;
+}

--- a/components/scans/cve-hosts-panel.tsx
+++ b/components/scans/cve-hosts-panel.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { IconArrowUpRight, IconX } from "@/components/ui-icons";
+import { CveDescription } from "@/components/intel/cve-description";
+import { severityBadgeClass } from "@/lib/cve-format";
+import { formatScanDateTime } from "@/lib/scan-format";
+import type { ScanCveRow } from "@/components/scans/scan-cve-tab";
+
+const HOSTS_PER_PAGE = 10;
+
+function hostHref(hostname: string) {
+  const h = hostname.trim();
+  if (!h) return "#";
+  if (/^https?:\/\//i.test(h)) return h;
+  return `https://${h}`;
+}
+
+export function CveHostsPanel({
+  cve,
+  onClose,
+}: {
+  cve: ScanCveRow;
+  onClose: () => void;
+}) {
+  const [mounted, setMounted] = useState(false);
+  const [page, setPage] = useState(1);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    setPage(1);
+  }, [cve]);
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
+  if (!mounted) return null;
+
+  const totalPages = Math.max(1, Math.ceil(cve.hosts.length / HOSTS_PER_PAGE));
+  const safePage = Math.min(page, totalPages);
+  const pagedHosts = cve.hosts.slice(
+    (safePage - 1) * HOSTS_PER_PAGE,
+    safePage * HOSTS_PER_PAGE,
+  );
+
+  return createPortal(
+    <>
+      <div className="fixed inset-0 z-[90] bg-void/50" aria-hidden onClick={onClose} />
+
+      <aside
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="cve-panel-title"
+        className="glass-panel fixed inset-y-0 right-0 z-[100] flex w-full max-w-[560px] flex-col rounded-none border-l border-line shadow-lift"
+      >
+        {/* Header */}
+        <div className="shrink-0 border-b border-line px-5 pb-4 pt-5">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <h2 className="text-[12px] font-medium text-muted">CVE</h2>
+              <div className="mt-1.5 flex min-w-0 items-center gap-2">
+                <Link
+                  href={`/intel/cve/${encodeURIComponent(cve.cveId)}`}
+                  id="cve-panel-title"
+                  className="min-w-0 truncate text-[18px] font-bold leading-tight tracking-tight text-cream hover:text-accent"
+                >
+                  {cve.cveId}
+                </Link>
+                {cve.severity ? (
+                  <span
+                    className={`shrink-0 rounded-md px-2 py-0.5 text-[10px] font-semibold ${severityBadgeClass(
+                      cve.severity,
+                    )}`}
+                  >
+                    {cve.severity}
+                    {cve.score != null ? ` · ${cve.score.toFixed(1)}` : ""}
+                  </span>
+                ) : null}
+              </div>
+              <p className="mt-2 font-mono text-[10px] text-muted">
+                Published {formatScanDateTime(cve.published)}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close panel"
+              className="flex size-8 shrink-0 items-center justify-center rounded-lg text-muted transition-colors hover:bg-[var(--nav-hover-bg)] hover:text-cream"
+            >
+              <IconX className="size-4" />
+            </button>
+          </div>
+        </div>
+
+        {/* Body */}
+        <div className="min-h-0 flex-1 overflow-y-auto px-5 py-5">
+          {/* Description */}
+          <div className="mb-6">
+            <h3 className="text-[11px] font-semibold uppercase tracking-wider text-muted">
+              Description
+            </h3>
+            <CveDescription
+              text={cve.description}
+              className="mt-2 text-[12px] leading-relaxed text-cream/90"
+            />
+          </div>
+
+          <div className="mb-6 border-t border-line" aria-hidden />
+
+          {/* Affected hosts table — mirrors the tech-hosts panel style */}
+          <div className="mb-3 text-left">
+            <h3 className="text-[13px] font-semibold text-cream">Affected hosts</h3>
+            <p className="mt-1 text-[11px] leading-relaxed text-muted">
+              Subdomains whose fingerprinted technology matches this CVE.
+            </p>
+          </div>
+
+          <div className="overflow-hidden rounded-lg border border-line text-left">
+            <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,0.8fr)_minmax(0,0.5fr)_auto] items-center gap-x-2 border-b border-line bg-[var(--table-header-bg)] px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted">
+              <div>Host</div>
+              <div>Technology</div>
+              <div>Version</div>
+              <div aria-hidden />
+            </div>
+            <div className="divide-y divide-line">
+              {pagedHosts.map((h, i) => (
+                <div
+                  key={`${h.hostnameNormalized}-${h.technology}-${i}`}
+                  className="group grid grid-cols-[minmax(0,1fr)_minmax(0,0.8fr)_minmax(0,0.5fr)_auto] items-center gap-x-2 px-2 py-1 text-left"
+                >
+                  <div
+                    className="min-w-0 truncate font-mono text-[10px] text-cream"
+                    title={h.hostnameNormalized}
+                  >
+                    {h.hostnameNormalized}
+                  </div>
+                  <div
+                    className="min-w-0 truncate font-mono text-[10px] text-muted"
+                    title={h.technology}
+                  >
+                    {h.technology}
+                  </div>
+                  <div className="min-w-0 truncate font-mono text-[10px] text-muted tabular-nums">
+                    {h.matchedVersion ?? "—"}
+                  </div>
+                  <a
+                    href={hostHref(h.hostnameNormalized)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label={`Visit ${h.hostnameNormalized}`}
+                    title={`Visit ${h.hostnameNormalized}`}
+                    className="flex size-5 items-center justify-center rounded text-muted transition-colors hover:bg-[var(--nav-hover-bg)] hover:text-cream"
+                  >
+                    <IconArrowUpRight className="size-3" />
+                  </a>
+                </div>
+              ))}
+            </div>
+            <CvePanelSimplePagination
+              page={safePage}
+              totalPages={totalPages}
+              onPageChange={setPage}
+            />
+          </div>
+        </div>
+      </aside>
+    </>,
+    document.body,
+  );
+}
+
+function CvePanelSimplePagination({
+  page,
+  totalPages,
+  onPageChange,
+}: {
+  page: number;
+  totalPages: number;
+  onPageChange: (p: number) => void;
+}) {
+  if (totalPages <= 1) return null;
+  return (
+    <div className="mt-1 flex items-center justify-between border-t border-line px-2 py-1 text-[10px] text-muted">
+      <button
+        type="button"
+        disabled={page <= 1}
+        onClick={() => onPageChange(page - 1)}
+        className="rounded px-1.5 py-0.5 font-medium transition-colors hover:text-cream disabled:opacity-30"
+      >
+        Prev
+      </button>
+      <span className="font-mono tabular-nums">
+        {page} / {totalPages}
+      </span>
+      <button
+        type="button"
+        disabled={page >= totalPages}
+        onClick={() => onPageChange(page + 1)}
+        className="rounded px-1.5 py-0.5 font-medium transition-colors hover:text-cream disabled:opacity-30"
+      >
+        Next
+      </button>
+    </div>
+  );
+}

--- a/components/scans/scan-cve-tab.tsx
+++ b/components/scans/scan-cve-tab.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { ScanPanelHeading } from "@/components/scans/scan-panel-heading";
+import { TablePagination } from "@/components/table-pagination";
+import { useCveHostsPanel } from "@/components/scans/cve-hosts-panel-provider";
+import { IconChevronRight } from "@/components/ui-icons";
+import { severityBadgeClass } from "@/lib/cve-format";
+
+export type ScanCveHost = {
+  hostnameNormalized: string;
+  technology: string;
+  matchedVersion: string | null;
+};
+
+export type ScanCveRow = {
+  cveId: string;
+  severity: string | null;
+  score: number | null;
+  published: string;
+  description: string;
+  hosts: ScanCveHost[];
+  hostCount: number;
+};
+
+export function ScanCveTab({
+  cves,
+  totalItems,
+  currentPage,
+  totalPages,
+  perPage,
+  basePath,
+  isCompleted,
+}: {
+  cves: ScanCveRow[];
+  totalItems: number;
+  currentPage: number;
+  totalPages: number;
+  perPage: number;
+  basePath: string;
+  isCompleted: boolean;
+}) {
+  const tableFixedParams = { tab: "cves" };
+
+  return (
+    <div className="space-y-4">
+      <div className="glass-panel overflow-hidden rounded-2xl">
+        <div className="border-b border-line bg-[var(--table-header-bg)] px-5 py-4">
+          <ScanPanelHeading
+            title="CVEs matched in this scan"
+            description={
+              isCompleted
+                ? "Vulnerabilities matched against fingerprinted technologies (version-confirmed)."
+                : "CVEs matched so far for this in-progress or partial scan."
+            }
+          />
+        </div>
+
+        {/* Column header — mirrors the other tabs' header rows. */}
+        <div className="hidden border-b border-line bg-[var(--table-header-bg)] px-5 py-2.5 text-[10px] font-semibold uppercase tracking-wider text-muted sm:grid sm:grid-cols-12 sm:gap-3">
+          <div className="col-span-2">CVE ID</div>
+          <div className="col-span-1">Severity</div>
+          <div className="col-span-1">Score</div>
+          <div className="col-span-6">Description</div>
+          <div className="col-span-1 text-right">Hosts</div>
+          <div className="col-span-1" aria-hidden />
+        </div>
+
+        <div className="divide-y divide-line">
+          {cves.length === 0 ? (
+            <div className="px-5 py-8 text-center text-[13px] text-muted">
+              No CVEs matched. Enable the CVE Match engine, fetch CVE data, and re-run the scan.
+            </div>
+          ) : (
+            cves.map((c) => <ScanCveRowItem key={c.cveId} row={c} />)
+          )}
+        </div>
+
+        <TablePagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          totalItems={totalItems}
+          perPage={perPage}
+          basePath={basePath}
+          fixedParams={tableFixedParams}
+        />
+      </div>
+    </div>
+  );
+}
+
+function ScanCveRowItem({ row }: { row: ScanCveRow }) {
+  const { openCvePanel } = useCveHostsPanel();
+
+  return (
+    <button
+      type="button"
+      onClick={() => openCvePanel(row)}
+      className="group flex w-full flex-col gap-2 px-5 py-3 text-left transition-colors hover:bg-white/5 focus:outline-none focus-visible:bg-white/5 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/35 sm:grid sm:grid-cols-12 sm:items-center sm:gap-3"
+    >
+      {/* CVE ID */}
+      <div className="col-span-2 min-w-0 truncate font-mono text-[12px] text-cream group-hover:text-accent">
+        {row.cveId}
+      </div>
+
+      {/* Severity */}
+      <div className="col-span-1 min-w-0">
+        {row.severity ? (
+          <span
+            className={`inline-block rounded-md px-2 py-0.5 text-[10px] font-semibold ${severityBadgeClass(
+              row.severity,
+            )}`}
+          >
+            {row.severity}
+          </span>
+        ) : (
+          <span className="text-[11px] text-muted">—</span>
+        )}
+      </div>
+
+      {/* Score */}
+      <div className="col-span-1 font-mono text-[11px] text-cream tabular-nums">
+        {row.score != null ? row.score.toFixed(1) : "—"}
+      </div>
+
+      {/* Description */}
+      <div
+        className="col-span-6 min-w-0 truncate text-[11px] text-muted"
+        title={row.description}
+      >
+        {row.description}
+      </div>
+
+      {/* Host count + chevron */}
+      <div className="col-span-2 flex items-center justify-between gap-2 sm:justify-end">
+        <span className="font-mono text-[11px] text-cream">
+          {row.hostCount.toLocaleString()}
+        </span>
+        <IconChevronRight
+          className="size-4 shrink-0 text-muted opacity-60 transition-all group-hover:text-accent group-hover:opacity-100"
+          aria-hidden
+        />
+      </div>
+    </button>
+  );
+}

--- a/components/settings-client.tsx
+++ b/components/settings-client.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import { apiUrl } from "@/lib/api-url";
 import { CategoryIconPicker } from "@/components/category-icon-picker";
+import { SettingsCveCard } from "@/components/settings-cve-card";
 import { IconPencil, IconTrash } from "@/components/nav-icons";
 import {
   DEFAULT_CATEGORY_ICON_KEY,
@@ -52,6 +53,11 @@ const SCAN_ENGINE_OPTIONS = [
     id: "WAPPALYZER",
     label: "Wappalyzer",
     description: "Technology fingerprinting (CMS, frameworks, servers) per subdomain.",
+  },
+  {
+    id: "CVE_MATCH",
+    label: "CVE Match",
+    description: "Correlate fingerprinted technologies against the stored CVE database. Requires CVE data fetched below.",
   },
 ] as const;
 
@@ -521,6 +527,8 @@ export function SettingsClient({
               </p>
             ) : null}
           </div>
+
+          <SettingsCveCard />
 
           <div className="glass-panel rounded-2xl p-6 lg:col-span-5">
             <div className="text-[10px] font-semibold uppercase tracking-[0.25em] text-accent">Global proxy</div>

--- a/components/settings-cve-card.tsx
+++ b/components/settings-cve-card.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { apiUrl } from "@/lib/api-url";
+import { formatScanDateTime } from "@/lib/scan-format";
+
+type CveStatus = {
+  hasApiKey: boolean;
+  status: "IDLE" | "RUNNING" | "COMPLETED" | "FAILED";
+  coveredUntil: string | null;
+  oldestPublished: string | null;
+  lastFetchedAt: string | null;
+  totalStored: number;
+  progressCurrent: number;
+  progressTotal: number;
+  errorMessage: string | null;
+};
+
+const RANGE_OPTIONS = [
+  { id: "7d", label: "7 days" },
+  { id: "30d", label: "30 days" },
+  { id: "6mo", label: "6 months" },
+  { id: "1y", label: "1 year" },
+  { id: "custom", label: "Custom" },
+] as const;
+
+export function SettingsCveCard() {
+  const [data, setData] = useState<CveStatus | null>(null);
+  const [apiKeyDraft, setApiKeyDraft] = useState("");
+  const [range, setRange] = useState<(typeof RANGE_OPTIONS)[number]["id"]>("30d");
+  const [customStart, setCustomStart] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const r = await fetch(apiUrl("/api/settings/cve"), { cache: "no-store" });
+      const j: CveStatus = await r.json();
+      setData(j);
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  // Poll while a fetch is running.
+  useEffect(() => {
+    if (data?.status === "RUNNING") {
+      if (!pollRef.current) {
+        pollRef.current = setInterval(() => void load(), 2000);
+      }
+    } else if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+    return () => {
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+    };
+  }, [data?.status, load]);
+
+  async function saveKey() {
+    setBusy(true);
+    setErr(null);
+    try {
+      const r = await fetch(apiUrl("/api/settings/cve"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ apiKey: apiKeyDraft || null }),
+      });
+      const j = await r.json().catch(() => null);
+      if (!r.ok) throw new Error(j?.error ?? `HTTP ${r.status}`);
+      setApiKeyDraft("");
+      await load();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "Failed to save key");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function startFetch() {
+    setBusy(true);
+    setErr(null);
+    try {
+      const body: { range: string; customStart?: string } = { range };
+      if (range === "custom") {
+        if (!customStart) throw new Error("Pick a custom start date");
+        body.customStart = new Date(customStart).toISOString();
+      }
+      const r = await fetch(apiUrl("/api/settings/cve/fetch"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const j = await r.json().catch(() => null);
+      if (!r.ok) throw new Error(j?.error ?? `HTTP ${r.status}`);
+      await load();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "Failed to start fetch");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const running = data?.status === "RUNNING";
+  const pct =
+    running && data && data.progressTotal > 0
+      ? Math.min(100, Math.round((data.progressCurrent / data.progressTotal) * 100))
+      : 0;
+
+  return (
+    <div className="glass-panel rounded-2xl p-6 lg:col-span-12">
+      <div className="flex flex-col gap-1">
+        <div className="text-[10px] font-semibold uppercase tracking-[0.25em] text-accent">
+          CVE intelligence (NVD)
+        </div>
+        <p className="mt-2 max-w-2xl text-[13px] leading-relaxed text-muted">
+          Provide an NVD API key and fetch CVE data from the National Vulnerability Database.
+          Stored CVEs power the CVE Match engine and the Intel &rsaquo; CVE DB browser.
+        </p>
+      </div>
+
+      {err ? (
+        <div className="mt-4 rounded-xl border border-warn/30 bg-warn/5 px-4 py-3 text-[12px] text-warn">
+          {err}
+        </div>
+      ) : null}
+
+      {/* API key row */}
+      <div className="mt-6">
+        <label className="text-[11px] font-medium text-muted" htmlFor="nvd-key">
+          NVD API key {data?.hasApiKey ? <span className="text-accent">(configured)</span> : null}
+        </label>
+        <div className="mt-2 flex gap-2">
+          <input
+            id="nvd-key"
+            type="password"
+            value={apiKeyDraft}
+            onChange={(e) => setApiKeyDraft(e.target.value)}
+            placeholder={data?.hasApiKey ? "•••••••• (replace)" : "Paste your NVD API key"}
+            className="min-w-0 flex-1 rounded-xl border border-line bg-[var(--tab-bg)] px-3 py-2.5 font-mono text-[12px] text-cream outline-none focus:border-accent/50"
+          />
+          <button
+            type="button"
+            onClick={() => void saveKey()}
+            disabled={busy || apiKeyDraft.length === 0}
+            className="shrink-0 rounded-xl border border-line px-4 py-2.5 text-[13px] font-medium text-cream transition-colors hover:bg-[var(--nav-hover-bg)] disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Save key
+          </button>
+        </div>
+        <p className="mt-1.5 text-[11px] text-muted">
+          Without a key, NVD limits requests heavily (fetching is slower). Request one at{" "}
+          <a
+            href="https://nvd.nist.gov/developers/request-an-api-key"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent hover:text-accent-dim"
+          >
+            nvd.nist.gov
+          </a>
+          .
+        </p>
+      </div>
+
+      {/* Fetch controls */}
+      <div className="mt-6 rounded-xl border border-line bg-black/10 p-4">
+        <div className="text-[11px] font-medium text-muted">Fetch window</div>
+        <div className="mt-2 flex flex-wrap items-center gap-2">
+          {RANGE_OPTIONS.map((o) => (
+            <button
+              key={o.id}
+              type="button"
+              onClick={() => setRange(o.id)}
+              disabled={running}
+              className={[
+                "rounded-lg border px-3 py-1.5 text-[12px] font-medium transition-colors disabled:opacity-50",
+                range === o.id
+                  ? "border-accent/50 bg-accent/15 text-accent"
+                  : "border-line bg-[var(--tab-bg)] text-cream hover:bg-[var(--nav-hover-bg)]",
+              ].join(" ")}
+            >
+              {o.label}
+            </button>
+          ))}
+          {range === "custom" ? (
+            <input
+              type="date"
+              value={customStart}
+              onChange={(e) => setCustomStart(e.target.value)}
+              disabled={running}
+              className="rounded-lg border border-line bg-[var(--tab-bg)] px-3 py-1.5 text-[12px] text-cream outline-none focus:border-accent/50"
+            />
+          ) : null}
+          <button
+            type="button"
+            onClick={() => void startFetch()}
+            disabled={busy || running}
+            className="ml-auto rounded-xl bg-gradient-to-r from-accent to-accent-dim px-5 py-2 text-[13px] font-semibold text-void disabled:opacity-60"
+          >
+            {running ? "Fetching…" : "Fetch CVEs"}
+          </button>
+        </div>
+
+        {running ? (
+          <div className="mt-4">
+            <div className="flex items-center justify-between text-[11px] text-muted">
+              <span>
+                Fetching from NVD… {data?.progressCurrent.toLocaleString()} /{" "}
+                {data?.progressTotal.toLocaleString()}
+              </span>
+              <span className="font-mono tabular-nums">{pct}%</span>
+            </div>
+            <div className="mt-1.5 h-1.5 w-full overflow-hidden rounded-full bg-[var(--tab-bg)]">
+              <div
+                className="h-full rounded-full bg-accent transition-all"
+                style={{ width: `${pct}%` }}
+              />
+            </div>
+          </div>
+        ) : null}
+
+        {data?.status === "FAILED" && data.errorMessage ? (
+          <div className="mt-3 rounded-lg border border-warn/30 bg-warn/5 px-3 py-2 text-[11px] text-warn">
+            Last fetch failed: {data.errorMessage}
+          </div>
+        ) : null}
+      </div>
+
+      {/* Stored summary */}
+      <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <div className="rounded-xl border border-line bg-black/10 px-3 py-2.5">
+          <div className="text-[10px] font-semibold uppercase tracking-wider text-muted">
+            CVEs stored
+          </div>
+          <div className="mt-1 font-mono text-[14px] font-semibold text-cream">
+            {(data?.totalStored ?? 0).toLocaleString()}
+          </div>
+        </div>
+        <div className="rounded-xl border border-line bg-black/10 px-3 py-2.5">
+          <div className="text-[10px] font-semibold uppercase tracking-wider text-muted">
+            Oldest CVE
+          </div>
+          <div className="mt-1 font-mono text-[11px] text-cream">
+            {data?.oldestPublished ? formatScanDateTime(data.oldestPublished) : "—"}
+          </div>
+        </div>
+        <div className="rounded-xl border border-line bg-black/10 px-3 py-2.5">
+          <div className="text-[10px] font-semibold uppercase tracking-wider text-muted">
+            Covered until
+          </div>
+          <div className="mt-1 font-mono text-[11px] text-cream">
+            {data?.coveredUntil ? formatScanDateTime(data.coveredUntil) : "—"}
+          </div>
+        </div>
+        <div className="rounded-xl border border-line bg-black/10 px-3 py-2.5">
+          <div className="text-[10px] font-semibold uppercase tracking-wider text-muted">
+            Last fetch
+          </div>
+          <div className="mt-1 font-mono text-[11px] text-cream">
+            {data?.lastFetchedAt ? formatScanDateTime(data.lastFetchedAt) : "—"}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -14,6 +14,7 @@ import {
   IconCheckCircle,
   IconLayoutDashboard,
   IconSettings,
+  IconShield,
 } from "@/components/ui-icons";
 
 type NavIcon = ComponentType<{ className?: string }>;
@@ -105,6 +106,17 @@ export function Sidebar({ categories }: { categories: SidebarExtensionCategory[]
           label: "All Findings",
           icon: IconAlertTriangle,
           match: (p, sp) => p.startsWith("/findings") && !sp.get("urlCategory"),
+        },
+      ],
+    },
+    {
+      title: "Intelligence",
+      items: [
+        {
+          href: "/intel/cve",
+          label: "CVE Database",
+          icon: IconShield,
+          match: (p: string) => p.startsWith("/intel/cve"),
         },
       ],
     },

--- a/engines/nvd/index.ts
+++ b/engines/nvd/index.ts
@@ -1,0 +1,224 @@
+import axios from "axios";
+import { SocksProxyAgent } from "socks-proxy-agent";
+
+export const NVD_CVE_API = "https://services.nvd.nist.gov/rest/json/cves/2.0";
+export const NVD_RESULTS_PER_PAGE = 2000;
+/** NVD allows a maximum 120-day window per lastMod query. */
+export const NVD_MAX_WINDOW_DAYS = 120;
+
+/**
+ * NVD requires ISO-8601 with an explicit UTC offset and rejects (or silently
+ * ignores) a bare "Z" suffix from `Date.toISOString()`. When the date filter is
+ * ignored, NVD returns the ENTIRE database instead of the requested window, so
+ * formatting this correctly is critical. Format: 2026-06-14T13:31:32.338+00:00
+ */
+export function toNvdDate(d: Date): string {
+  return d.toISOString().replace(/Z$/, "+00:00");
+}
+
+export type NvdCveParsed = {
+  id: string;
+  published: Date;
+  lastModified: Date;
+  cvssScore: number | null;
+  cvssSeverity: string | null;
+  cvssVector: string | null;
+  description: string;
+  cpeProducts: string[];
+  cpeConfigs: unknown;
+  references: string[];
+};
+
+export type NvdPageResult = {
+  status: number;
+  totalResults: number;
+  startIndex: number;
+  resultsPerPage: number;
+  cves: NvdCveParsed[];
+};
+
+type NvdRawCve = {
+  id: string;
+  published: string;
+  lastModified: string;
+  descriptions?: Array<{ lang: string; value: string }>;
+  metrics?: {
+    cvssMetricV31?: Array<{ cvssData?: { baseScore?: number; baseSeverity?: string; vectorString?: string }; baseSeverity?: string }>;
+    cvssMetricV30?: Array<{ cvssData?: { baseScore?: number; baseSeverity?: string; vectorString?: string }; baseSeverity?: string }>;
+    cvssMetricV2?: Array<{ cvssData?: { baseScore?: number; vectorString?: string }; baseSeverity?: string }>;
+  };
+  configurations?: unknown[];
+  references?: Array<{ url: string }>;
+};
+
+function pickCvss(metrics: NvdRawCve["metrics"]): {
+  score: number | null;
+  severity: string | null;
+  vector: string | null;
+} {
+  const v31 = metrics?.cvssMetricV31?.[0];
+  if (v31?.cvssData) {
+    return {
+      score: v31.cvssData.baseScore ?? null,
+      severity: (v31.cvssData.baseSeverity ?? v31.baseSeverity ?? null)?.toUpperCase() ?? null,
+      vector: v31.cvssData.vectorString ?? null,
+    };
+  }
+  const v30 = metrics?.cvssMetricV30?.[0];
+  if (v30?.cvssData) {
+    return {
+      score: v30.cvssData.baseScore ?? null,
+      severity: (v30.cvssData.baseSeverity ?? v30.baseSeverity ?? null)?.toUpperCase() ?? null,
+      vector: v30.cvssData.vectorString ?? null,
+    };
+  }
+  const v2 = metrics?.cvssMetricV2?.[0];
+  if (v2?.cvssData) {
+    return {
+      score: v2.cvssData.baseScore ?? null,
+      severity: v2.baseSeverity?.toUpperCase() ?? null,
+      vector: v2.cvssData.vectorString ?? null,
+    };
+  }
+  return { score: null, severity: null, vector: null };
+}
+
+/**
+ * Extract product tokens from a CVE's CPE configuration nodes.
+ * Stores BOTH the full "vendor:product" and the bare "product" so that techs
+ * fingerprinted without a CPE (only a product name, e.g. "nginx") can still be
+ * looked up via Postgres array `hasSome`, which matches array elements exactly.
+ */
+export function extractCpeProducts(configurations: unknown[]): string[] {
+  const out = new Set<string>();
+  const walk = (node: unknown) => {
+    if (!node || typeof node !== "object") return;
+    const n = node as Record<string, unknown>;
+    if (Array.isArray(n.nodes)) n.nodes.forEach(walk);
+    if (Array.isArray(n.cpeMatch)) {
+      for (const m of n.cpeMatch as Array<Record<string, unknown>>) {
+        const criteria = typeof m.criteria === "string" ? m.criteria : "";
+        // CPE 2.3: cpe:2.3:part:vendor:product:version:...
+        const parts = criteria.split(":");
+        if (parts.length >= 5) {
+          const vendor = parts[3];
+          const product = parts[4];
+          if (vendor && product && vendor !== "*" && product !== "*") {
+            out.add(`${vendor}:${product}`);
+            out.add(product);
+          }
+        }
+      }
+    }
+  };
+  for (const c of configurations ?? []) walk(c);
+  return Array.from(out);
+}
+
+function parseCve(raw: NvdRawCve): NvdCveParsed {
+  const cvss = pickCvss(raw.metrics);
+  const desc =
+    raw.descriptions?.find((d) => d.lang === "en")?.value ??
+    raw.descriptions?.[0]?.value ??
+    "";
+  const configs = raw.configurations ?? [];
+  return {
+    id: raw.id,
+    published: new Date(raw.published),
+    lastModified: new Date(raw.lastModified),
+    cvssScore: cvss.score,
+    cvssSeverity: cvss.severity,
+    cvssVector: cvss.vector,
+    description: desc,
+    cpeProducts: extractCpeProducts(configs),
+    cpeConfigs: configs,
+    references: (raw.references ?? []).map((r) => r.url).filter(Boolean).slice(0, 50),
+  };
+}
+
+/**
+ * Fetch a single page of CVEs PUBLISHED within [pubStartDate, pubEndDate].
+ *
+ * We deliberately filter on publication date rather than lastModified: NVD
+ * periodically performs bulk re-scoring that bumps `lastModified` on hundreds
+ * of thousands of CVEs at once, so a lastMod window can match the entire DB.
+ * Publication date is stable (a CVE is published exactly once) and matches the
+ * user's mental model of "CVEs from the last N days".
+ * Never throws — returns status code; caller decides retry/backoff.
+ */
+export async function fetchNvdCvePage(params: {
+  apiKey?: string | null;
+  startIndex: number;
+  pubStartDate: Date;
+  pubEndDate: Date;
+  proxyUrl?: string | null;
+}): Promise<NvdPageResult> {
+  const agent = params.proxyUrl ? new SocksProxyAgent(params.proxyUrl) : undefined;
+  const headers: Record<string, string> = {
+    // NVD rejects requests without a browser-like User-Agent (503).
+    "User-Agent":
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
+    Accept: "application/json",
+  };
+  if (params.apiKey) headers.apiKey = params.apiKey;
+
+  try {
+    const res = await axios.get(NVD_CVE_API, {
+      params: {
+        startIndex: params.startIndex,
+        resultsPerPage: NVD_RESULTS_PER_PAGE,
+        pubStartDate: toNvdDate(params.pubStartDate),
+        pubEndDate: toNvdDate(params.pubEndDate),
+      },
+      // Do not let axios re-encode the "+" in the offset into a space.
+      paramsSerializer: { encode: encodeURIComponent },
+      headers,
+      timeout: 60_000,
+      httpsAgent: agent,
+      httpAgent: agent,
+      proxy: false,
+      validateStatus: () => true,
+    });
+
+    if (res.status !== 200 || typeof res.data !== "object" || res.data == null) {
+      return { status: res.status, totalResults: 0, startIndex: params.startIndex, resultsPerPage: 0, cves: [] };
+    }
+
+    const data = res.data as {
+      totalResults?: number;
+      startIndex?: number;
+      resultsPerPage?: number;
+      vulnerabilities?: Array<{ cve: NvdRawCve }>;
+    };
+
+    const cves = (data.vulnerabilities ?? [])
+      .map((v) => v.cve)
+      .filter(Boolean)
+      .map(parseCve);
+
+    return {
+      status: 200,
+      totalResults: data.totalResults ?? 0,
+      startIndex: data.startIndex ?? params.startIndex,
+      resultsPerPage: data.resultsPerPage ?? cves.length,
+      cves,
+    };
+  } catch {
+    return { status: 599, totalResults: 0, startIndex: params.startIndex, resultsPerPage: 0, cves: [] };
+  }
+}
+
+/** Split [start, end] into <=120-day windows (NVD constraint). */
+export function splitDateWindows(start: Date, end: Date): Array<{ start: Date; end: Date }> {
+  const windows: Array<{ start: Date; end: Date }> = [];
+  const maxMs = NVD_MAX_WINDOW_DAYS * 24 * 60 * 60 * 1000;
+  let cursor = start.getTime();
+  const endMs = end.getTime();
+  while (cursor < endMs) {
+    const winEnd = Math.min(cursor + maxMs, endMs);
+    windows.push({ start: new Date(cursor), end: new Date(winEnd) });
+    cursor = winEnd;
+  }
+  if (windows.length === 0) windows.push({ start, end });
+  return windows;
+}

--- a/lib/cve-fetch.ts
+++ b/lib/cve-fetch.ts
@@ -1,0 +1,184 @@
+import type { PrismaClient } from "@prisma/client";
+import { CveFetchStatus, Prisma } from "@prisma/client";
+import {
+  fetchNvdCvePage,
+  splitDateWindows,
+  NVD_RESULTS_PER_PAGE,
+  type NvdCveParsed,
+} from "@/engines/nvd";
+
+const SINGLETON = "singleton";
+const MAX_PAGE_RETRIES = 5;
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** Polite request spacing: ~0.7s with key, 6s without (NVD rate limits). */
+function requestDelayMs(hasKey: boolean): number {
+  return hasKey ? 700 : 6000;
+}
+
+export type CveFetchRange = "7d" | "30d" | "6mo" | "1y" | "custom";
+
+export function resolveStartDate(range: CveFetchRange, customStart?: Date | null): Date {
+  const now = Date.now();
+  const day = 24 * 60 * 60 * 1000;
+  switch (range) {
+    case "7d":
+      return new Date(now - 7 * day);
+    case "30d":
+      return new Date(now - 30 * day);
+    case "6mo":
+      return new Date(now - 182 * day);
+    case "1y":
+      return new Date(now - 365 * day);
+    case "custom":
+      return customStart ?? new Date(now - 30 * day);
+  }
+}
+
+async function getState(prisma: PrismaClient) {
+  return prisma.cveFetchState.upsert({
+    where: { id: SINGLETON },
+    create: { id: SINGLETON },
+    update: {},
+  });
+}
+
+/** Persist a batch of parsed CVEs (only those with CPE products — matchable). */
+async function persistCves(prisma: PrismaClient, cves: NvdCveParsed[]): Promise<number> {
+  const matchable = cves.filter((c) => c.cpeProducts.length > 0);
+  if (matchable.length === 0) return 0;
+
+  // Bulk upsert via raw SQL ON CONFLICT for speed.
+  const values = matchable.map(
+    (c) =>
+      Prisma.sql`(${c.id}, ${c.published}, ${c.lastModified}, ${c.cvssScore}, ${c.cvssSeverity}, ${c.cvssVector}, ${c.description}, ${c.cpeProducts}, ${JSON.stringify(c.cpeConfigs)}::jsonb, ${c.references}, now())`,
+  );
+
+  await prisma.$executeRaw`
+    INSERT INTO "cve" (id, published, last_modified, cvss_score, cvss_severity, cvss_vector, description, cpe_products, cpe_configs, "references", created_at)
+    VALUES ${Prisma.join(values)}
+    ON CONFLICT (id) DO UPDATE SET
+      last_modified = EXCLUDED.last_modified,
+      cvss_score = EXCLUDED.cvss_score,
+      cvss_severity = EXCLUDED.cvss_severity,
+      cvss_vector = EXCLUDED.cvss_vector,
+      description = EXCLUDED.description,
+      cpe_products = EXCLUDED.cpe_products,
+      cpe_configs = EXCLUDED.cpe_configs,
+      "references" = EXCLUDED."references"
+  `;
+  return matchable.length;
+}
+
+/**
+ * Run a full CVE fetch over [startDate, now], chunked into 120-day windows,
+ * paginating each. Updates CveFetchState progress as it goes. Idempotent on
+ * CVE id (upsert).
+ */
+export async function runCveFetch(
+  prisma: PrismaClient,
+  params: { apiKey?: string | null; startDate: Date; proxyUrl?: string | null },
+): Promise<{ stored: number }> {
+  const end = new Date();
+  const windows = splitDateWindows(params.startDate, end);
+  const hasKey = Boolean(params.apiKey);
+  const delay = requestDelayMs(hasKey);
+
+  await prisma.cveFetchState.upsert({
+    where: { id: SINGLETON },
+    create: { id: SINGLETON, status: CveFetchStatus.RUNNING, progressCurrent: 0, progressTotal: 0 },
+    update: { status: CveFetchStatus.RUNNING, errorMessage: null, progressCurrent: 0, progressTotal: 0 },
+  });
+
+  let storedTotal = 0;
+  let grandTotalResults = 0;
+  let processedResults = 0;
+
+  try {
+    for (const win of windows) {
+      let startIndex = 0;
+      let windowTotal = Infinity;
+
+      while (startIndex < windowTotal) {
+        // Fetch one page with bounded retries for any non-200 (NVD frequently
+        // returns 403/429/503 when unauthenticated). Escalating backoff.
+        let page = await fetchNvdCvePage({
+          apiKey: params.apiKey,
+          startIndex,
+          pubStartDate: win.start,
+          pubEndDate: win.end,
+          proxyUrl: params.proxyUrl,
+        });
+        let attempt = 0;
+        while (page.status !== 200 && attempt < MAX_PAGE_RETRIES) {
+          attempt += 1;
+          await sleep(delay * (2 + attempt)); // escalate: 3x,4x,5x...
+          page = await fetchNvdCvePage({
+            apiKey: params.apiKey,
+            startIndex,
+            pubStartDate: win.start,
+            pubEndDate: win.end,
+            proxyUrl: params.proxyUrl,
+          });
+        }
+        if (page.status !== 200) {
+          // Give up on this window after exhausting retries.
+          throw new Error(
+            `NVD request failed (status ${page.status}) after ${MAX_PAGE_RETRIES} retries. ` +
+              `Try again later${params.apiKey ? "" : " or add an NVD API key for higher rate limits"}.`,
+          );
+        }
+
+        if (windowTotal === Infinity) {
+          windowTotal = page.totalResults;
+          grandTotalResults += page.totalResults;
+        }
+
+        storedTotal += await persistCves(prisma, page.cves);
+        processedResults += page.cves.length;
+        startIndex += NVD_RESULTS_PER_PAGE;
+
+        await prisma.cveFetchState.update({
+          where: { id: SINGLETON },
+          data: {
+            progressCurrent: processedResults,
+            progressTotal: Math.max(grandTotalResults, processedResults),
+          },
+        });
+
+        if (page.cves.length === 0) break;
+        await sleep(delay);
+      }
+    }
+
+    const totalStored = await prisma.cve.count();
+    await prisma.cveFetchState.update({
+      where: { id: SINGLETON },
+      data: {
+        status: CveFetchStatus.COMPLETED,
+        coveredUntil: end,
+        lastFetchedAt: new Date(),
+        totalStored,
+        progressCurrent: processedResults,
+        progressTotal: Math.max(grandTotalResults, processedResults),
+      },
+    });
+
+    return { stored: storedTotal };
+  } catch (e) {
+    await prisma.cveFetchState.update({
+      where: { id: SINGLETON },
+      data: {
+        status: CveFetchStatus.FAILED,
+        errorMessage: e instanceof Error ? e.message : String(e),
+      },
+    });
+    throw e;
+  }
+}
+
+export async function getCveFetchState(prisma: PrismaClient) {
+  const state = await getState(prisma);
+  const totalStored = await prisma.cve.count();
+  return { ...state, totalStored };
+}

--- a/lib/cve-format.ts
+++ b/lib/cve-format.ts
@@ -1,0 +1,88 @@
+/**
+ * A single "vulnerable" CPE entry parsed from a CVE's cpeConfigs, flattened
+ * into something readable for the UI.
+ */
+export type AffectedConfig = {
+  vendor: string;
+  product: string;
+  /** Human label, e.g. "apache:http_server". */
+  label: string;
+  /** Human version constraint, e.g. "2.4.17 ≤ v < 2.4.68" or "any version". */
+  versionLabel: string;
+};
+
+type CpeMatch = {
+  criteria?: string;
+  vulnerable?: boolean;
+  versionStartIncluding?: string;
+  versionStartExcluding?: string;
+  versionEndIncluding?: string;
+  versionEndExcluding?: string;
+};
+
+function versionConstraintLabel(m: CpeMatch, pinnedVersion: string): string {
+  if (pinnedVersion && pinnedVersion !== "*" && pinnedVersion !== "-") {
+    return `= ${pinnedVersion}`;
+  }
+  const lo = m.versionStartIncluding
+    ? `${m.versionStartIncluding} ≤ `
+    : m.versionStartExcluding
+      ? `${m.versionStartExcluding} < `
+      : "";
+  const hi = m.versionEndExcluding
+    ? `< ${m.versionEndExcluding}`
+    : m.versionEndIncluding
+      ? `≤ ${m.versionEndIncluding}`
+      : "";
+  if (!lo && !hi) return "any version";
+  return `${lo}v ${hi}`.trim();
+}
+
+/** Flatten a CVE's cpeConfigs into a de-duplicated list of vulnerable products. */
+export function parseAffectedConfigs(configs: unknown): AffectedConfig[] {
+  const out = new Map<string, AffectedConfig>();
+  const walk = (node: unknown) => {
+    if (!node || typeof node !== "object") return;
+    const n = node as Record<string, unknown>;
+    if (Array.isArray(n.nodes)) n.nodes.forEach(walk);
+    if (Array.isArray(n.cpeMatch)) {
+      for (const raw of n.cpeMatch as CpeMatch[]) {
+        if (raw.vulnerable === false) continue;
+        const parts = (raw.criteria ?? "").split(":");
+        if (parts.length < 6) continue;
+        const vendor = parts[3];
+        const product = parts[4];
+        const pinned = parts[5];
+        if (!vendor || !product || vendor === "*" || product === "*") continue;
+        const label = `${vendor}:${product}`;
+        const versionLabel = versionConstraintLabel(raw, pinned);
+        const key = `${label}|${versionLabel}`;
+        if (!out.has(key)) out.set(key, { vendor, product, label, versionLabel });
+      }
+    }
+  };
+  if (Array.isArray(configs)) configs.forEach(walk);
+  else walk(configs);
+  return Array.from(out.values());
+}
+
+/** Normalize a vendor/product token for loose comparison against a tech name. */
+export function normalizeProductToken(s: string): string {
+  return s.replace(/[_\s-]+/g, "").toLowerCase();
+}
+
+/** Tailwind classes for a CVE severity badge, aligned with scan status badges. */
+export function severityBadgeClass(severity: string | null | undefined): string {
+  switch ((severity ?? "").toUpperCase()) {
+    case "CRITICAL":
+      return "bg-warn/25 text-warn";
+    case "HIGH":
+      return "bg-warn/15 text-warn";
+    case "MEDIUM":
+      return "bg-accent/15 text-accent";
+    case "LOW":
+      return "bg-muted/15 text-muted";
+    default:
+      return "bg-muted/10 text-muted";
+  }
+}

--- a/lib/cve-match.ts
+++ b/lib/cve-match.ts
@@ -1,0 +1,197 @@
+import type { PrismaClient } from "@prisma/client";
+
+/**
+ * CVE matching for a single technology.
+ *
+ * Strategy (CPE + name/version fuzzy):
+ *  1. Derive candidate "vendor:product" / "product" tokens from the tech's
+ *     CPE (if present) and its name.
+ *  2. Find CVEs whose flattened cpe_products array overlaps those tokens
+ *     (GIN-friendly array && operator).
+ *  3. If the tech has a known version, refine using the CVE's raw cpe_configs
+ *     version ranges; otherwise keep the candidate (loose match).
+ */
+
+export type TechForMatch = {
+  id: string;
+  name: string;
+  version: string | null;
+  cpe: string | null;
+};
+
+/** Tokens used to look up candidate CVEs by product. */
+export function deriveCpeProductTokens(tech: TechForMatch): string[] {
+  const tokens = new Set<string>();
+
+  // From CPE: cpe:2.3:a:vendor:product:version:...
+  if (tech.cpe) {
+    const parts = tech.cpe.split(":");
+    if (parts.length >= 5) {
+      const vendor = parts[3];
+      const product = parts[4];
+      if (vendor && product && vendor !== "*" && product !== "*") {
+        tokens.add(`${vendor}:${product}`);
+      }
+    }
+  }
+
+  // From name: normalize "Apache Traffic Server" -> "apache_traffic_server"
+  const slug = tech.name.trim().toLowerCase().replace(/[\s.]+/g, "_").replace(/[^a-z0-9_-]/g, "");
+  if (slug) {
+    // Match either vendor:product or product alone (any vendor) below.
+    tokens.add(slug);
+  }
+  return Array.from(tokens);
+}
+
+type CpeMatchNode = { criteria?: string; vulnerable?: boolean; versionStartIncluding?: string; versionStartExcluding?: string; versionEndIncluding?: string; versionEndExcluding?: string };
+
+function cmpVersion(a: string, b: string): number {
+  const pa = a.split(/[.\-+]/).map((x) => parseInt(x, 10));
+  const pb = b.split(/[.\-+]/).map((x) => parseInt(x, 10));
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const x = Number.isNaN(pa[i]) ? 0 : pa[i] ?? 0;
+    const y = Number.isNaN(pb[i]) ? 0 : pb[i] ?? 0;
+    if (x !== y) return x < y ? -1 : 1;
+  }
+  return 0;
+}
+
+/** Whether a known version falls within a CVE config's version range / exact match. */
+export function versionMatchesConfigs(version: string, configs: unknown, productTokens: string[]): boolean {
+  const tokenSet = new Set(productTokens);
+  // Vendors the tech is known to belong to (derived from a real CPE). When we
+  // know the vendor, we refuse to match a CVE's CPE that belongs to a DIFFERENT
+  // vendor even if the bare product name collides — this prevents e.g. an
+  // "apache:http_server" tech from matching an "f5:nginx" CPE entry.
+  const knownVendors = new Set(
+    productTokens.filter((t) => t.includes(":")).map((t) => t.split(":")[0]),
+  );
+  let sawRangeForProduct = false;
+
+  const checkMatch = (m: CpeMatchNode): boolean | null => {
+    const criteria = m.criteria ?? "";
+    const parts = criteria.split(":");
+    if (parts.length < 6) return null;
+    const vendor = parts[3];
+    const vendorProduct = `${parts[3]}:${parts[4]}`;
+    const product = parts[4];
+    const cpeVersion = parts[5];
+
+    // If the tech's vendor is known, the CVE entry's vendor must match it.
+    if (knownVendors.size > 0 && vendor && vendor !== "*" && !knownVendors.has(vendor)) {
+      return null;
+    }
+    const relevant = tokenSet.has(vendorProduct) || tokenSet.has(product);
+    if (!relevant) return null;
+    sawRangeForProduct = true;
+
+    // Exact version pinned in CPE.
+    if (cpeVersion && cpeVersion !== "*" && cpeVersion !== "-") {
+      return cmpVersion(version, cpeVersion) === 0;
+    }
+
+    // Range bounds.
+    let ok = true;
+    if (m.versionStartIncluding) ok = ok && cmpVersion(version, m.versionStartIncluding) >= 0;
+    if (m.versionStartExcluding) ok = ok && cmpVersion(version, m.versionStartExcluding) > 0;
+    if (m.versionEndIncluding) ok = ok && cmpVersion(version, m.versionEndIncluding) <= 0;
+    if (m.versionEndExcluding) ok = ok && cmpVersion(version, m.versionEndExcluding) < 0;
+    return ok;
+  };
+
+  const walk = (node: unknown): boolean => {
+    if (!node || typeof node !== "object") return false;
+    const n = node as Record<string, unknown>;
+    if (Array.isArray(n.nodes) && n.nodes.some(walk)) return true;
+    if (Array.isArray(n.cpeMatch)) {
+      for (const m of n.cpeMatch as CpeMatchNode[]) {
+        const r = checkMatch(m);
+        if (r === true) return true;
+      }
+    }
+    return false;
+  };
+
+  for (const c of (Array.isArray(configs) ? configs : [])) {
+    if (walk(c)) return true;
+  }
+  // If no version range existed for this product, fall back to loose match.
+  return !sawRangeForProduct;
+}
+
+export type CveMatchHit = { cveId: string; matchedVersion: string | null };
+
+/** Find CVE ids matching a single technology. */
+export async function matchTechToCves(
+  prisma: PrismaClient,
+  tech: TechForMatch,
+  limit = 200,
+): Promise<CveMatchHit[]> {
+  const tokens = deriveCpeProductTokens(tech);
+  if (tokens.length === 0) return [];
+
+  // Candidate CVEs: cpe_products array overlaps any token, OR product suffix.
+  // We over-fetch on vendor:product and bare product, then refine in JS.
+  const bareProducts = tokens.map((t) => (t.includes(":") ? t.split(":")[1] : t));
+  const candidates = await prisma.cve.findMany({
+    where: {
+      OR: [
+        { cpeProducts: { hasSome: tokens } },
+        // bare product against either side of "vendor:product"
+        ...bareProducts.map((p) => ({ cpeProducts: { hasSome: [p] } })),
+      ],
+    },
+    select: { id: true, cpeProducts: true, cpeConfigs: true, cvssScore: true, description: true },
+    orderBy: { published: "desc" },
+    take: limit * 3,
+  });
+
+  // Vendors known from the tech's CPE (empty when Wappalyzer gave no CPE).
+  const knownVendors = new Set(
+    tokens.filter((t) => t.includes(":")).map((t) => t.split(":")[0]),
+  );
+
+  // When the tech has NO CPE vendor we can only bare-match on product name,
+  // which is where NVD's cross-vendor mis-tagging bites (e.g. an Apache-only
+  // CVE that also lists "f5:nginx" in its config). In that weak case we require
+  // the product token to be corroborated by the CVE description before claiming
+  // a match. Strong vendor:product matches are trusted without this check.
+  const hasKnownVendor = knownVendors.size > 0;
+  const productTermsForCorroboration = Array.from(
+    new Set(bareProducts.map((p) => p.replace(/_/g, " ").toLowerCase()).filter((p) => p.length > 2)),
+  );
+  const corroboratedByDescription = (description: string): boolean => {
+    const d = description.toLowerCase();
+    return productTermsForCorroboration.some((term) => d.includes(term));
+  };
+
+  const hits: CveMatchHit[] = [];
+  for (const c of candidates) {
+    // Confirm product overlap (vendor:product or bare product on either side).
+    // When the tech's vendor is known, require the CVE product to share that
+    // vendor — prevents bare-name collisions across vendors (apache vs f5).
+    const prodOverlap = c.cpeProducts.some((cp) => {
+      const cpVendor = cp.includes(":") ? cp.split(":")[0] : "";
+      const cpBare = cp.includes(":") ? cp.split(":")[1] : cp;
+      if (knownVendors.size > 0 && cpVendor && !knownVendors.has(cpVendor)) return false;
+      return tokens.includes(cp) || bareProducts.includes(cpBare) || bareProducts.includes(cp);
+    });
+    if (!prodOverlap) continue;
+
+    // Require a known version AND a confirmed version-range match. Without a
+    // detected version we cannot verify exposure, so we skip rather than guess
+    // (otherwise a modern server matches decades-old CVEs by product name).
+    if (!tech.version) continue;
+
+    // Weak (no-vendor) matches must be corroborated by the description.
+    if (!hasKnownVendor && !corroboratedByDescription(c.description)) continue;
+
+    if (versionMatchesConfigs(tech.version, c.cpeConfigs, tokens)) {
+      hits.push({ cveId: c.id, matchedVersion: tech.version });
+    }
+    if (hits.length >= limit) break;
+  }
+  return hits;
+}

--- a/lib/nvd-key.ts
+++ b/lib/nvd-key.ts
@@ -1,0 +1,58 @@
+import { EngineProvider, type PrismaClient } from "@prisma/client";
+import { encryptSecretWithKey, decryptSecretWithKey } from "@/lib/encryption";
+import { resolveAppEncryptionKey } from "@/lib/app-encryption";
+import { utcDateOnly, currentIsoWeekKey, currentMonthKey } from "@/lib/quota-constants";
+
+/**
+ * The NVD API key is stored as a single ApiKey row under provider CVE_MATCH,
+ * consistent with how every other engine credential is persisted (encrypted
+ * secret + app encryption key). NVD needs only one global key, so we keep a
+ * single row and replace it on save.
+ */
+const PROVIDER = EngineProvider.CVE_MATCH;
+const LABEL = "NVD API key";
+
+export async function setNvdApiKey(prisma: PrismaClient, plain: string | null) {
+  // Always clear the existing key first (single-row semantics).
+  await prisma.apiKey.deleteMany({ where: { provider: PROVIDER } });
+  if (!plain) return;
+
+  const key = await resolveAppEncryptionKey(prisma);
+  const secretEncrypted = encryptSecretWithKey(key, plain);
+  await prisma.apiKey.create({
+    data: {
+      provider: PROVIDER,
+      label: LABEL,
+      secretEncrypted,
+      proxyUrl: null,
+      usageCountDate: utcDateOnly(new Date()),
+      usageCount: 0,
+      usageWeekKey: currentIsoWeekKey(),
+      usageCountWeekly: 0,
+      usageMonthKey: currentMonthKey(),
+      usageCountMonthly: 0,
+      isDisabled: false,
+    },
+  });
+}
+
+export async function getNvdApiKey(prisma: PrismaClient): Promise<string | null> {
+  const row = await prisma.apiKey.findFirst({
+    where: { provider: PROVIDER, isDisabled: false },
+    orderBy: { createdAt: "desc" },
+  });
+  if (!row) return null;
+  try {
+    const key = await resolveAppEncryptionKey(prisma);
+    return decryptSecretWithKey(key, row.secretEncrypted);
+  } catch {
+    return null;
+  }
+}
+
+export async function hasNvdApiKey(prisma: PrismaClient): Promise<boolean> {
+  const count = await prisma.apiKey.count({
+    where: { provider: PROVIDER, isDisabled: false },
+  });
+  return count > 0;
+}

--- a/lib/queue.ts
+++ b/lib/queue.ts
@@ -2,8 +2,14 @@ import { Queue } from "bullmq";
 import { getRedis } from "@/lib/redis";
 
 export const SCAN_QUEUE_NAME = "recon-scan";
+export const CVE_FETCH_QUEUE_NAME = "recon-cve-fetch";
 
 export function getScanQueue() {
   const connection = getRedis();
   return new Queue(SCAN_QUEUE_NAME, { connection });
+}
+
+export function getCveFetchQueue() {
+  const connection = getRedis();
+  return new Queue(CVE_FETCH_QUEUE_NAME, { connection });
 }

--- a/lib/scan-pipeline.ts
+++ b/lib/scan-pipeline.ts
@@ -844,6 +844,60 @@ export async function runScanJob(prisma: PrismaClient, redis: Redis, scanJobId: 
 
   await checkCancelled(prisma, scanJobId);
 
+  /* ════════════════════════════════════════════
+   * Phase T5C: CVE matching (subdomain technologies × stored CVEs)
+   * ════════════════════════════════════════════ */
+  if (engines.includes(EngineProvider.CVE_MATCH)) {
+    const cveCount = await prisma.cve.count();
+    if (cveCount > 0) {
+      const { matchTechToCves } = await import("@/lib/cve-match");
+
+      const techRows = await prisma.subdomainTechnology.findMany({
+        where: { subdomain: { targetDomainId: target.id } },
+        select: { id: true, name: true, version: true, cpe: true },
+      });
+
+      await prisma.scanJob.update({
+        where: { id: scanJobId },
+        data: { phase: ScanPhase.T5C_CVE_MATCH, progressCurrent: 0, progressTotal: techRows.length },
+      });
+
+      let cveIdx = 0;
+      for (const tech of techRows) {
+        cveIdx += 1;
+        if (cveIdx % 25 === 0) await checkCancelled(prisma, scanJobId);
+
+        const hits = await matchTechToCves(prisma, tech);
+        for (const hit of hits) {
+          await prisma.subdomainTechnologyCve.upsert({
+            where: {
+              subdomainTechnologyId_cveId: {
+                subdomainTechnologyId: tech.id,
+                cveId: hit.cveId,
+              },
+            },
+            create: {
+              subdomainTechnologyId: tech.id,
+              cveId: hit.cveId,
+              scanJobId,
+              matchedVersion: hit.matchedVersion,
+            },
+            update: { scanJobId, matchedVersion: hit.matchedVersion },
+          });
+        }
+
+        if (shouldUpdateProgress(cveIdx, techRows.length, 2)) {
+          await prisma.scanJob.update({
+            where: { id: scanJobId },
+            data: { progressCurrent: cveIdx, progressTotal: techRows.length },
+          });
+        }
+      }
+    }
+  }
+
+  await checkCancelled(prisma, scanJobId);
+
   const finalCheck = await prisma.scanJob.findUnique({ where: { id: scanJobId }, select: { status: true } });
   if (finalCheck?.status !== ScanJobStatus.CANCELLED) {
     await syncTargetCachedFindingCount(prisma, target.id);

--- a/prisma/migrations/20260621125458_add_cve_intel/migration.sql
+++ b/prisma/migrations/20260621125458_add_cve_intel/migration.sql
@@ -1,0 +1,76 @@
+-- CreateEnum
+CREATE TYPE "CveFetchStatus" AS ENUM ('IDLE', 'RUNNING', 'COMPLETED', 'FAILED');
+
+-- AlterEnum
+ALTER TYPE "EngineProvider" ADD VALUE 'CVE_MATCH';
+
+-- AlterEnum
+ALTER TYPE "ScanPhase" ADD VALUE 'T5C_CVE_MATCH';
+
+-- CreateTable
+CREATE TABLE "cve" (
+    "id" TEXT NOT NULL,
+    "published" TIMESTAMP(3) NOT NULL,
+    "last_modified" TIMESTAMP(3) NOT NULL,
+    "cvss_score" DOUBLE PRECISION,
+    "cvss_severity" TEXT,
+    "cvss_vector" TEXT,
+    "description" TEXT NOT NULL,
+    "cpe_products" TEXT[],
+    "cpe_configs" JSONB NOT NULL,
+    "references" TEXT[],
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "cve_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "cve_fetch_state" (
+    "id" TEXT NOT NULL DEFAULT 'singleton',
+    "status" "CveFetchStatus" NOT NULL DEFAULT 'IDLE',
+    "covered_until" TIMESTAMP(3),
+    "last_fetched_at" TIMESTAMP(3),
+    "total_stored" INTEGER NOT NULL DEFAULT 0,
+    "progress_current" INTEGER NOT NULL DEFAULT 0,
+    "progress_total" INTEGER NOT NULL DEFAULT 0,
+    "error_message" TEXT,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "cve_fetch_state_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "subdomain_technology_cve" (
+    "id" TEXT NOT NULL,
+    "subdomain_technology_id" TEXT NOT NULL,
+    "cve_id" TEXT NOT NULL,
+    "scan_job_id" TEXT,
+    "matched_version" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "subdomain_technology_cve_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "cve_published_idx" ON "cve"("published" DESC);
+
+-- CreateIndex
+CREATE INDEX "cve_cvss_severity_idx" ON "cve"("cvss_severity");
+
+-- CreateIndex
+CREATE INDEX "cve_cvss_score_idx" ON "cve"("cvss_score");
+
+-- CreateIndex
+CREATE INDEX "subdomain_technology_cve_cve_id_idx" ON "subdomain_technology_cve"("cve_id");
+
+-- CreateIndex
+CREATE INDEX "subdomain_technology_cve_scan_job_id_idx" ON "subdomain_technology_cve"("scan_job_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "subdomain_technology_cve_subdomain_technology_id_cve_id_key" ON "subdomain_technology_cve"("subdomain_technology_id", "cve_id");
+
+-- AddForeignKey
+ALTER TABLE "subdomain_technology_cve" ADD CONSTRAINT "subdomain_technology_cve_subdomain_technology_id_fkey" FOREIGN KEY ("subdomain_technology_id") REFERENCES "subdomain_technology"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "subdomain_technology_cve" ADD CONSTRAINT "subdomain_technology_cve_cve_id_fkey" FOREIGN KEY ("cve_id") REFERENCES "cve"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,6 +12,7 @@ enum EngineProvider {
   WAYBACK_MACHINE
   URLSCAN
   WAPPALYZER
+  CVE_MATCH
 }
 
 enum ScanJobStatus {
@@ -30,7 +31,15 @@ enum ScanPhase {
   T4_WAYBACK_SUBDOMAINS
   T5_CONSOLIDATE
   T5B_WAPPALYZER
+  T5C_CVE_MATCH
   T6_ANALYSIS
+}
+
+enum CveFetchStatus {
+  IDLE
+  RUNNING
+  COMPLETED
+  FAILED
 }
 
 enum DeepScanState {
@@ -102,6 +111,7 @@ model SubdomainTechnology {
   cpe         String?
   firstSeenAt DateTime  @default(now()) @map("first_seen_at")
   lastSeenAt  DateTime  @updatedAt @map("last_seen_at")
+  cveMatches  SubdomainTechnologyCve[]
 
   @@unique([subdomainId, name])
   @@index([subdomainId])
@@ -335,4 +345,57 @@ model AppSetting {
   updatedAt DateTime @updatedAt @map("updated_at")
 
   @@map("app_setting")
+}
+
+model Cve {
+  id            String   @id // CVE-ID, e.g. CVE-2024-1234
+  published     DateTime
+  lastModified  DateTime @map("last_modified")
+  cvssScore     Float?   @map("cvss_score")
+  cvssSeverity  String?  @map("cvss_severity") // CRITICAL | HIGH | MEDIUM | LOW | NONE
+  cvssVector    String?  @map("cvss_vector")
+  description   String
+  // Flattened CPE products for fast matching: ["vendor:product", ...]
+  cpeProducts   String[] @map("cpe_products")
+  // Raw NVD configurations node for precise version-range matching.
+  cpeConfigs    Json     @map("cpe_configs")
+  references    String[]
+  createdAt     DateTime @default(now()) @map("created_at")
+  matches       SubdomainTechnologyCve[]
+
+  @@index([published(sort: Desc)])
+  @@index([cvssSeverity])
+  @@index([cvssScore])
+  @@map("cve")
+}
+
+model CveFetchState {
+  id            String         @id @default("singleton")
+  status        CveFetchStatus @default(IDLE)
+  // Most recent lastModified date covered by stored data (NVD incremental cursor).
+  coveredUntil  DateTime?      @map("covered_until")
+  lastFetchedAt DateTime?      @map("last_fetched_at")
+  totalStored   Int            @default(0) @map("total_stored")
+  progressCurrent Int          @default(0) @map("progress_current")
+  progressTotal   Int          @default(0) @map("progress_total")
+  errorMessage  String?        @map("error_message")
+  updatedAt     DateTime       @updatedAt @map("updated_at")
+
+  @@map("cve_fetch_state")
+}
+
+model SubdomainTechnologyCve {
+  id                    String              @id @default(uuid())
+  subdomainTechnologyId String              @map("subdomain_technology_id")
+  subdomainTechnology   SubdomainTechnology @relation(fields: [subdomainTechnologyId], references: [id], onDelete: Cascade)
+  cveId                 String              @map("cve_id")
+  cve                   Cve                 @relation(fields: [cveId], references: [id], onDelete: Cascade)
+  scanJobId             String?             @map("scan_job_id")
+  matchedVersion        String?             @map("matched_version")
+  createdAt             DateTime            @default(now()) @map("created_at")
+
+  @@unique([subdomainTechnologyId, cveId])
+  @@index([cveId])
+  @@index([scanJobId])
+  @@map("subdomain_technology_cve")
 }

--- a/scripts/_fresh.ts
+++ b/scripts/_fresh.ts
@@ -1,0 +1,26 @@
+import { prisma } from "@/lib/prisma";
+import { runCveFetch, resolveStartDate } from "@/lib/cve-fetch";
+import { matchTechToCves } from "@/lib/cve-match";
+(async()=>{
+  const start=resolveStartDate("30d");
+  console.log("fetch 30d pub window from", start.toISOString().slice(0,10));
+  const res=await runCveFetch(prisma,{apiKey:null,startDate:start,proxyUrl:null});
+  const total=await prisma.cve.count();
+  const oldest=await prisma.cve.findFirst({orderBy:{published:"asc"},select:{id:true,published:true}});
+  console.log("stored:",res.stored,"| total:",total,"| oldest:",oldest?.id,oldest?.published.toISOString().slice(0,10));
+
+  // re-match all techs strictly
+  const techs=await prisma.subdomainTechnology.findMany({select:{id:true,name:true,version:true,cpe:true}});
+  let withVer=0, hits=0;
+  for(const t of techs){
+    if(t.version) withVer++;
+    const h=await matchTechToCves(prisma,t);
+    for(const x of h){
+      await prisma.subdomainTechnologyCve.upsert({where:{subdomainTechnologyId_cveId:{subdomainTechnologyId:t.id,cveId:x.cveId}},create:{subdomainTechnologyId:t.id,cveId:x.cveId,matchedVersion:x.matchedVersion},update:{matchedVersion:x.matchedVersion}});
+      hits++;
+    }
+  }
+  console.log("techs:",techs.length,"| withVersion:",withVer,"| STRICT matches:",hits);
+  const sample=await prisma.subdomainTechnologyCve.findMany({take:10,select:{cveId:true,matchedVersion:true,subdomainTechnology:{select:{name:true,version:true}}}});
+  sample.forEach(s=>console.log(" ",s.cveId,"| tech:",s.subdomainTechnology.name,s.subdomainTechnology.version,"| matchedVer:",s.matchedVersion));
+})().finally(()=>process.exit(0));

--- a/scripts/_re.ts
+++ b/scripts/_re.ts
@@ -1,0 +1,16 @@
+import axios from "axios";
+const UA="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36";
+const sleep=(ms:number)=>new Promise(r=>setTimeout(r,ms));
+async function t(label:string,params:Record<string,string|number>){
+  for(let i=0;i<5;i++){
+    const r=await axios.get("https://services.nvd.nist.gov/rest/json/cves/2.0",{params,headers:{"User-Agent":UA,Accept:"application/json"},timeout:60000,validateStatus:()=>true});
+    if(r.status===200){console.log(label,"total:",r.data?.totalResults);return;}
+    process.stdout.write(`[${r.status}]`);await sleep(7000);
+  }
+  console.log(label,"FAIL");
+}
+(async()=>{
+  await t("7d Z      ",{resultsPerPage:1,lastModStartDate:"2026-06-14T13:31:32.338Z",lastModEndDate:"2026-06-21T13:31:32.338Z"});await sleep(7000);
+  await t("7d noTZ   ",{resultsPerPage:1,lastModStartDate:"2026-06-14T13:31:32.338",lastModEndDate:"2026-06-21T13:31:32.338"});await sleep(7000);
+  await t("7d +00:00 ",{resultsPerPage:1,lastModStartDate:"2026-06-14T13:31:32.338+00:00",lastModEndDate:"2026-06-21T13:31:32.338+00:00"});
+})().finally(()=>process.exit(0));

--- a/workers/scan-worker.ts
+++ b/workers/scan-worker.ts
@@ -5,8 +5,9 @@ import Redis from "ioredis";
 import { ScanJobStatus } from "@prisma/client";
 import { prisma } from "../lib/prisma";
 import { runScanJob } from "../lib/scan-pipeline";
-import { SCAN_QUEUE_NAME } from "../lib/queue";
+import { SCAN_QUEUE_NAME, CVE_FETCH_QUEUE_NAME } from "../lib/queue";
 import { resolveAppEncryptionKey } from "../lib/app-encryption";
+import { runCveFetch } from "../lib/cve-fetch";
 
 const url = process.env.REDIS_URL ?? "redis://127.0.0.1:6379";
 
@@ -55,6 +56,33 @@ async function main() {
   });
 
   console.info(`[worker] listening on ${SCAN_QUEUE_NAME} (concurrency=1)`);
+
+  // CVE fetch worker (NVD ingestion) — separate queue, concurrency 1.
+  const cveWorker = new Worker(
+    CVE_FETCH_QUEUE_NAME,
+    async (job) => {
+      const { apiKey, startDate, proxyUrl } = job.data as {
+        apiKey?: string | null;
+        startDate: string;
+        proxyUrl?: string | null;
+      };
+      await runCveFetch(prisma, {
+        apiKey: apiKey ?? null,
+        startDate: new Date(startDate),
+        proxyUrl: proxyUrl ?? null,
+      });
+    },
+    { connection: bullConnection, concurrency: 1 },
+  );
+
+  cveWorker.on("failed", (job, err) => {
+    console.error(`[worker] cve-fetch job ${job?.id} failed:`, err);
+  });
+  cveWorker.on("completed", (job) => {
+    console.info(`[worker] cve-fetch completed job ${job.id}`);
+  });
+
+  console.info(`[worker] listening on ${CVE_FETCH_QUEUE_NAME} (concurrency=1)`);
 }
 
 main().catch((e) => {


### PR DESCRIPTION
NVD CVE intelligence + vendor-aware matching + detailed CVE  page

- Add NVD 2.0 client, CVE fetch pipeline (T5C), bulk upsert with rate-limit
- Store NVD API key in ApiKey table (CVE_MATCH provider, encrypted)
- Vendor-aware matching: known-vendor tech only matches same-vendor CPE; exact-version only (no version -> skip), no loose fallback
- Store both vendor:product and bare product tokens for null-CPE lookups
- CVE database list/detail pages, server-side debounced search
- CVE detail page: parsed Affected configurations table (product + version range from NVD cpeConfigs) and Affected hosts with matched rule
- CVEs tab in scan observed page, host panel CVE badges
- Settings CVE card (key, fetch range, progress, stats)